### PR TITLE
Forced optional unwrapping fix when targeting simulators

### DIFF
--- a/Shared/Data/CoreData/CoreDataManager+Certificates.swift
+++ b/Shared/Data/CoreData/CoreDataManager+Certificates.swift
@@ -96,13 +96,15 @@ extension CoreDataManager {
 		try CertData.copyFile(from: p12Path, to: destinationDirectory)
 	}
 	
-	func getCertifcatePath(source: Certificate) -> URL {
-		let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-		let p = documentsDirectory
-			.appendingPathComponent("Certificates")
-			.appendingPathComponent((source.uuid)!)
-		return p
-	}
+    func getCertifcatePath(source: Certificate?) throws -> URL {
+        guard let source, let uuid = source.uuid else { throw FileProcessingError.missingFile("Certificate or UUID") }
+        let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let destinationDirectory = documentsDirectory
+            .appendingPathComponent("Certificates")
+            .appendingPathComponent(uuid)
+        
+        return destinationDirectory
+    }
 	
 	func deleteAllCertificateContent(for app: Certificate) {
 		do {

--- a/Shared/Signing/AppSigner.swift
+++ b/Shared/Signing/AppSigner.swift
@@ -65,7 +65,7 @@ func signInitialApp(options: AppSigningOptions, appPath: URL, completion: @escap
 			try updatePlugIns(options: options, app: tmpDirApp)
 			try removeDumbAssPlaceHolderExtension(options: options, app: tmpDirApp)
 			
-			let certPath = CoreDataManager.shared.getCertifcatePath(source: options.certificate!)
+            let certPath = try CoreDataManager.shared.getCertifcatePath(source: options.certificate)
 			let provisionPath = certPath.appendingPathComponent("\(options.certificate?.provisionPath ?? "")").path
 			let p12Path = certPath.appendingPathComponent("\(options.certificate?.p12Path ?? "")").path
 			
@@ -111,7 +111,7 @@ func resignApp(certificate: Certificate, appPath: URL, completion: @escaping (Bo
 	UIApplication.shared.isIdleTimerDisabled = true
 	DispatchQueue(label: "Resigning").async {
 		do {
-			let certPath = CoreDataManager.shared.getCertifcatePath(source: certificate)
+            let certPath = try CoreDataManager.shared.getCertifcatePath(source: certificate)
 			let provisionPath = certPath.appendingPathComponent("\(certificate.provisionPath ?? "")").path
 			let p12Path = certPath.appendingPathComponent("\(certificate.p12Path ?? "")").path
 			

--- a/iOS/Views/Apps/Signing/AppSigningViewController.swift
+++ b/iOS/Views/Apps/Signing/AppSigningViewController.swift
@@ -93,7 +93,11 @@ class AppSigningViewController: UITableViewController {
 		if (certs == nil) {
 			#if !targetEnvironment(simulator)
 			DispatchQueue.main.async {
-				let alert = UIAlertController(title: "Error", message: "You do not have a certificate selected, please select one in the certificates tab.", preferredStyle: .alert)
+                let alert = UIAlertController(
+                    title: "Error",
+                    message: "You do not have a certificate selected, please select or upload one in the signing section of the settings tab.",
+                    preferredStyle: .alert
+                )
 				alert.addAction(UIAlertAction(title: "Lame", style: .default) { _ in
 						self.dismiss(animated: true)
 					}


### PR DESCRIPTION
When playing around with the app I noticed a small bug that affects devs only where if you tap the sign CTA without any certificates selected or saved, the application crashes while trying to unwrap a forced optional variable

I don't know if it was intentional or not, since for real devices you do have code in place to somewhat handle the situation by dismissing the sheet view entirely unless a certificate is present (with a small rewording of the message info)

Let me know if this fix could be useful or not