### PR TITLE
Add Spanish translations

### DIFF
--- a/Shared/Localizations/es.lproj/Localizable.strings
+++ b/Shared/Localizations/es.lproj/Localizable.strings
@@ -8,171 +8,171 @@
 
 // MARK: - Generic
 // Unknown, default string for applications
-"UNKNOWN" = "Unknown";
+"UNKNOWN" = "Desconocido";
 // Default string
-"DEFAULT" = "Default";
+"DEFAULT" = "Por defecto";
 // Copy provided string in a menu
-"COPY" = "Copy";
+"COPY" = "Copiar";
 // Delete item
-"DELETE" = "Delete";
+"DELETE" = "Borrar";
 // Cancel alert action
-"CANCEL" = "Cancel";
+"CANCEL" = "Cancelar";
 // Done action
-"DONE" = "Done";
+"DONE" = "Hecho";
 // Dismiss action
-"DISMISS" = "Dismiss";
-// Dismiss 2 action
-"LAME" = "Lame";
+"DISMISS" = "Descartar";
+// OK action
+"LAME" = "OK";
 // Save action
-"SAVE" = "Save";
+"SAVE" = "Guardar";
 // Set action
-"SET" = "Save";
+"SET" = "Guardar";
 // OK action
 "OK" = "OK";
 // Continue action
-"CONTINUE" = "Continue";
+"CONTINUE" = "Continuar";
 
 // MARK: - Alerts
 // Alert titles
-"ALERT_SUCCESS" = "Success";
-"ALERT_TRACE" = "Trace";
+"ALERT_SUCCESS" = "Suceso";
+"ALERT_TRACE" = "Rastro";
 "ALERT_ERROR" = "Error";
-"ALERT_CRITICAL" = "Critical";
+"ALERT_CRITICAL" = "Crítico";
 
 // MARK: - Error messages
 // Installer Error Title
-"ERROR_INSTALLER" = "Installer";
+"ERROR_INSTALLER" = "Instalador";
 // Installer Error Description
-"ERROR_INSTALLER_DESCRIPTION" = "Failed to load SSL certificates";
-"ERROR_ZSIGN_FAILED" = "Signing failed.";
-"ERROR_FAILED_TO_READ_MOBILEPROVISION" = "Failed to read mobileprovision file";
+"ERROR_INSTALLER_DESCRIPTION" = "No se pudo cargar los certificados SSL";
+"ERROR_ZSIGN_FAILED" = "Firma fallada.";
+"ERROR_FAILED_TO_READ_MOBILEPROVISION" = "No se pudo leer archivo mobileprovision";
 
 // MARK: - Success messages
 // Successfully signed an application
-"SUCCESS_SIGNED" = "Successfully signed %@";
+"SUCCESS_SIGNED" = "Firmado %@ correctamente";
 // Successfully resigned an application
-"SUCCESS_RESIGN" = "Successfully resigned!";
+"SUCCESS_RESIGN" = "¡Refirmado correctamente!";
 
 // MARK: - Onboarding
 // Welcome to Feather!!!!!!!!
-"ONBOARDING_WELCOMETITLE_1" = "Welcome to";
+"ONBOARDING_WELCOMETITLE_1" = "Bienvenido a";
 // First feature inside of onboarding
-"ONBOARDING_CELL_1_TITLE" = "Sideload On Device";
-"ONBOARDING_CELL_1_DESCRIPTION" = "Sideload apps without a computer, all done from your device.";
+"ONBOARDING_CELL_1_TITLE" = "Sideload En Dispositivo";
+"ONBOARDING_CELL_1_DESCRIPTION" = "Sideloadea apps sin un ordenador, todo desde tu dispositivo.";
 // Second feature inside of onboarding
-"ONBOARDING_CELL_2_TITLE" = "Customize Apps";
-"ONBOARDING_CELL_2_DESCRIPTION" = "Manage and customize your apps for your needs.";
+"ONBOARDING_CELL_2_TITLE" = "Personalizar Apps";
+"ONBOARDING_CELL_2_DESCRIPTION" = "Administra y personaliza tus aplicaciones a tu gusto.";
 // Third feature inside of onboarding
-"ONBOARDING_CELL_3_TITLE" = "And Much More!";
-"ONBOARDING_CELL_3_DESCRIPTION" = "AltStore repositories, import IPA's, easy certificate switching, and much more.";
+"ONBOARDING_CELL_3_TITLE" = "¡Y Mucho Más!";
+"ONBOARDING_CELL_3_DESCRIPTION" = "Repositorios de AltStore, importar IPAs, cambio de certificados rápido, y mucho más.";
 // "Developed by Samara. Made for users who are passionate for sideloading and freedom. Many features included inside. Learn more..."
-"ONBOARDING_FOOTER" = "Developed by Samara. Made for users who are passionate for sideloading and freedom. Many features included inside.";
-"ONBOARDING_FOOTER_LINK" = "Learn more...";
+"ONBOARDING_FOOTER" = "Desarrollado por Samara. Hecho para usuarios apasionados por el sideloading y la libertad. Muchas funciones incluidas.";
+"ONBOARDING_FOOTER_LINK" = "Descubre más...";
 // Continue button to exit onboarding
-"ONBOARDING_CONTINUE_BUTTON" = "Continue";
+"ONBOARDING_CONTINUE_BUTTON" = "Continuar";
 
 // MARK: - Tab area
 // Sources tab
-"TAB_SOURCES" = "Sources";
+"TAB_SOURCES" = "Fuentes";
 // Library tab
-"TAB_LIBRARY" = "Library";
+"TAB_LIBRARY" = "Biblioteca";
 // Settings tab
-"TAB_SETTINGS" = "Settings";
+"TAB_SETTINGS" = "Ajustes";
 
 // MARK: - TransferPreview
 // Packaging application to get ready for install
-"TRANSFER_PREVIEW_PACKAGING" = "Packaging...";
+"TRANSFER_PREVIEW_PACKAGING" = "Empaquetando...";
 // Ready to install package
-"TRANSFER_PREVIEW_READY" = "Ready To Install";
+"TRANSFER_PREVIEW_READY" = "Listo para Instalar";
 // Opening manifest.plist for iOS
-"TRANSFER_PREVIEW_SENDING_MANIFEST" = "Sending Manifest...";
+"TRANSFER_PREVIEW_SENDING_MANIFEST" = "Enviando Manifesto...";
 // iOS is retrieving IPA file
-"TRANSFER_PREVIEW_SENDING_PAYLOAD" = "Sending Payload...";
+"TRANSFER_PREVIEW_SENDING_PAYLOAD" = "Enviando Carga útil...";
 // Done transferring IPA file
-"TRANSFER_PREVIEW_DONE" = "Done";
+"TRANSFER_PREVIEW_DONE" = "Hecho";
 // Completed packaging so you can share
-"TRANSFER_PREVIEW_COMPLETED" = "Completed";
+"TRANSFER_PREVIEW_COMPLETED" = "Completado";
 
 // MARK: - SourcesViewController
 // Repositories title
-"SOURCES_VIEW_CONTROLLER_REPOSITORIES" = "Repositories";
+"SOURCES_VIEW_CONTROLLER_REPOSITORIES" = "Repositorios";
 // Add repo button
-"SOURCES_VIEW_CONTROLLER_ADD_SOURCES" = "Add Repo";
+"SOURCES_VIEW_CONTROLLER_ADD_SOURCES" = "Añadir Repo";
 // Number of sources, i.e. "100 Sources"
-"SOURCES_VIEW_CONTROLLER_NUMBER_OF_SOURCES" = "%@ Sources";
+"SOURCES_VIEW_CONTROLLER_NUMBER_OF_SOURCES" = "%@ Fuentes";
 // Search sources in search bar
-"SOURCES_VIEW_CONTROLLER_SEARCH_SOURCES" = "Search Sources";
+"SOURCES_VIEW_CONTROLLER_SEARCH_SOURCES" = "Buscar Fuentes";
 
 // MARK: - SourcesViewController - Add Sources
-"SOURCES_VIEW_ADD_SOURCES_ALERT_TITLE" = "Add Source";
-"SOURCES_VIEW_ADD_SOURCES_ALERT_DESCRIPTION" = "Add Altstore Repo URL";
+"SOURCES_VIEW_ADD_SOURCES_ALERT_TITLE" = "Añadir Fuente";
+"SOURCES_VIEW_ADD_SOURCES_ALERT_DESCRIPTION" = "Añadir URL de Repositorio de Altstore";
 
 // MARK: - SourcesViewController -> SourcesAppViewController
 // Number of apps, i.e. "444 Apps"
 "SOURCES_APP_VIEW_CONTROLLER_NUMBER_OF_APPS" = "%@ Apps";
 // Search apps in search bar
-"SOURCES_APP_VIEW_CONTROLLER_SEARCH_APPS" = "Search Apps";
+"SOURCES_APP_VIEW_CONTROLLER_SEARCH_APPS" = "Buscar Apps";
 
 // MARK: - SourcesViewController ... - Cells
 // Default subtitle string
-"SOURCES_CELLS_DEFAULT_SUBTITLE" = "An awesome application.";
+"SOURCES_CELLS_DEFAULT_SUBTITLE" = "Una aplicación fantástica.";
 // Default description string
-"SOURCES_CELLS_DEFAULT_DESCRIPTION" = "A cool description.";
+"SOURCES_CELLS_DEFAULT_DESCRIPTION" = "Una descripción chula.";
 
 // MARK: - SourceAppViewController ... - Actions
 // Available Versions Alert Title
-"SOURCES_CELLS_ACTIONS_HOLD_AVAILABLE_VERSIONS" = "Available Versions";
+"SOURCES_CELLS_ACTIONS_HOLD_AVAILABLE_VERSIONS" = "Versiones Disponibles";
 
 // MARK: - AppsInformationViewController
 // Application Section
-"APPS_INFORMATION_SECTION_TITLE_NAME" = "Application";
+"APPS_INFORMATION_SECTION_TITLE_NAME" = "Aplicación";
 // Bundle Section
 "APPS_INFORMATION_SECTION_TITLE_NAME" = "Bundle";
 
 //
-"APPS_INFORMATION_TITLE_DELETED_FILE" = "Deleted File";
-"APPS_INFORMATION_TITLE_DELETED_FILE_TITLE" = "File has been deleted.";
-"APPS_INFORMATION_TITLE_DELETED_FILE_DESCRIPTION" = "This is a useless entry, it does not have a file and Feather will not allow you to install it. It's recommended you delete by swiping on the cell in the Apps tab.";
+"APPS_INFORMATION_TITLE_DELETED_FILE" = "Archivo eliminado";
+"APPS_INFORMATION_TITLE_DELETED_FILE_TITLE" = "El archivo ha sido eliminado.";
+"APPS_INFORMATION_TITLE_DELETED_FILE_DESCRIPTION" = "Esta entrada es inútil, no tiene ningún archivo y Feather no te permitirá instalarla. Se recomienda que la elimines deslizando la celda en la página de Apps.";
 // Application Section
-"APPS_INFORMATION_TITLE_NAME" = "Name";
-"APPS_INFORMATION_TITLE_VERSION" = "Version";
-"APPS_INFORMATION_TITLE_IDENTIFIER" = "Identifier";
-"APPS_INFORMATION_TITLE_SIZE" = "Size";
+"APPS_INFORMATION_TITLE_NAME" = "Nombre";
+"APPS_INFORMATION_TITLE_VERSION" = "Versión";
+"APPS_INFORMATION_TITLE_IDENTIFIER" = "Identificador";
+"APPS_INFORMATION_TITLE_SIZE" = "Tamaño";
 //
-"APPS_INFORMATION_TITLE_DATE_ADDED" = "Date Added";
+"APPS_INFORMATION_TITLE_DATE_ADDED" = "Fecha agregado";
 // Bundle Section
-"APPS_INFORMATION_TITLE_BUNDLE_NAME" = "Bundle Name";
-"APPS_INFORMATION_TITLE_BUNDLE_PATH" = "Bundle Path";
-"APPS_INFORMATION_TITLE_ICON_FILE" = "Icon File";
+"APPS_INFORMATION_TITLE_BUNDLE_NAME" = "Nombre del Bundle";
+"APPS_INFORMATION_TITLE_BUNDLE_PATH" = "Ruta del Bundle";
+"APPS_INFORMATION_TITLE_ICON_FILE" = "Archivo del Icono";
 //
-"APPS_INFORMATION_TITLE_OPEN_IN_FILES" = "Open in Files";
+"APPS_INFORMATION_TITLE_OPEN_IN_FILES" = "Abrir en Archivos";
 
 // MARK: - AppSigningViewController
-"APP_SIGNING_VIEW_CONTROLLER_CELL_ADD_TWEAKS" = "Add Tweaks";
-"APP_SIGNING_VIEW_CONTROLLER_CELL_ADVANCED" = "Advanced";
-"APP_SIGNING_VIEW_CONTROLLER_START_SIGNING" = "Start Signing";
+"APP_SIGNING_VIEW_CONTROLLER_CELL_ADD_TWEAKS" = "Añadir Tweaks";
+"APP_SIGNING_VIEW_CONTROLLER_CELL_ADVANCED" = "Avanzado";
+"APP_SIGNING_VIEW_CONTROLLER_START_SIGNING" = "Empezar a Firmar";
 
 // MARK: - AppSigningViewController - No Certificates Alert
 "APP_SIGNING_VIEW_CONTROLLER_NO_CERTS_ALERT_TITLE" = "Error";
-"APP_SIGNING_VIEW_CONTROLLER_NO_CERTS_ALERT_DESCRIPTION" = "You do not have a certificate selected, please select or upload one in the signing section of the settings tab.";
+"APP_SIGNING_VIEW_CONTROLLER_NO_CERTS_ALERT_DESCRIPTION" = "No se ha seleccionado ningún certificado, por favor seleccione o suba uno en la sección Firmar de la página de ajustes.";
 
 // MARK: - AppSigningViewController -> AppSigningInputViewController
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_CELL_PPQCHECK" = "PPQCheck is Enabled";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_CELL_PPQCHECK_DESCRIPTION" = "PPQCheck is a way for Apple to check if the app you're opening matches another bundle identifier found on the App Store, the check happens on the first time you open the signed installed application. We have an option for you to avoid this, however you will no longer receive the benefits of notifications and such relating to the default identifier.";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_CELL_PPQCHECK" = "PPQCheck está Activado";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_CELL_PPQCHECK_DESCRIPTION" = "PPQCheck es una forma en la que Apple comprueba si la aplicación que abres coincide con un identificador de Bundle en el App Store, la comprobación tiene lugar la primera vez que abres una aplicación firmada instalada. Tenemos una opción para evitar esto, al coste de no poder recibir notificaciones ni otros benificios del identificador por defecto.";
 
 // MARK: - AppSigningViewController -> AppSigningAdvancedViewController
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_SECTION_TITLE_APPEARENCE" = "Appearence";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_SECTION_TITLE_MINIMUM_APP_VERSION" = "Minimum App Version";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_SECTION_TITLE_PROPERTIES" = "Properties";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_SECTION_TITLE_APPEARENCE" = "Apariencia";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_SECTION_TITLE_MINIMUM_APP_VERSION" = "Versión de App mínima";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_SECTION_TITLE_PROPERTIES" = "Propiedades";
 
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_PLUGINS" = "Remove all PlugIns";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_UISUPPORTEDDEVICES" = "Remove UISupportedDevices";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_URLSCHEME" = "Remove URLScheme";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_ALLOW_BROWSING_DOCUMENTS" = "Allow browsing Documents";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_ALLOW_ITUNES_SHARING" = "Allow iTunes Sharing";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_FORCE_PRO_MOTION" = "Force Pro Motion";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_FORCE_FULLSCREEN" = "Force Fullscreen";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_DELETE_PLACEHOLDER_WATCH_APP" = "Delete Placeholder Watch App";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_PLUGINS" = "Quitar todos los PlugIns";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_UISUPPORTEDDEVICES" = "Quitar UISupportedDevices";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_URLSCHEME" = "Quitar URLScheme";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_ALLOW_BROWSING_DOCUMENTS" = "Permitir acceso a Documentos";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_ALLOW_ITUNES_SHARING" = "Permitir compartir por iTunes";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_FORCE_PRO_MOTION" = "Forzar Pro Motion";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_FORCE_FULLSCREEN" = "Forzar Pantalla completa";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_DELETE_PLACEHOLDER_WATCH_APP" = "Borrar App Placeholder de Reloj";
 
 // MARK: - AppSigningViewController -> AppSigningTweakViewController
 "APP_SIGNING_TWEAK_VIEW_CONTROLLER_TITLE" = "Tweaks";
@@ -180,110 +180,110 @@
 // MARK: - SettingsViewController
 // Headers
 "SETTINGS_VIEW_CONTROLLER_SECTION_TITLE_GENERAL" = "General";
-"SETTINGS_VIEW_CONTROLLER_SECTION_TITLE_SIGNING" = "Signing";
-"SETTINGS_VIEW_CONTROLLER_SECTION_TITLE_SIGNING_SERVER" = "Signing Server";
+"SETTINGS_VIEW_CONTROLLER_SECTION_TITLE_SIGNING" = "Firmar";
+"SETTINGS_VIEW_CONTROLLER_SECTION_TITLE_SIGNING_SERVER" = "Servidor de firmas";
 
 // Footers
-"SETTINGS_VIEW_CONTROLLER_SECTION_FOOTER_ISSUES" = "If any issues occur within Feather please report it via the GitHub repository. When submitting an issue, be sure to submit any logs.";
-"SETTINGS_VIEW_CONTROLLER_SECTION_FOOTER_SERVER_LIMITATIONS" = "Sadly due to limitations server certificates will need to be re-renewed every year to keep Feathers local features working properly, tap this button to retrieve the most up-to-date files from our repositories.";
+"SETTINGS_VIEW_CONTROLLER_SECTION_FOOTER_ISSUES" = "Si ocurre algún problema con Feather, por favor repórtelo en el repositorio de GitHub. Al reportar un problema, recuerde enviar registros.";
+"SETTINGS_VIEW_CONTROLLER_SECTION_FOOTER_SERVER_LIMITATIONS" = "Desafortunadamente debido a limitaciones los certificados de servidor deberán ser re-renovados cada año para mantener las funciones locales de Feather funcionando correctamente, presione este botón para obtener los archivos actualizados de nuestros repositorios.";
 
 // Cell Titles
 // About Feather
-"SETTINGS_VIEW_CONTROLLER_CELL_ABOUT" = "About %@";
-"SETTINGS_VIEW_CONTROLLER_CELL_SUBMIT_FEEDBACK" = "Submit Feedback";
-"SETTINGS_VIEW_CONTROLLER_CELL_GITHUB" = "GitHub Repository";
-"SETTINGS_VIEW_CONTROLLER_CELL_DISPLAY" = "Display";
-"SETTINGS_VIEW_CONTROLLER_CELL_APP_ICON" = "App Icon";
-"SETTINGS_VIEW_CONTROLLER_CELL_CURRENT_CERTIFICATE_NOSELECTED" = "No certificates selected";
-"SETTINGS_VIEW_CONTROLLER_CELL_ADD_CERTIFICATES" = "Add Certificate";
-"SETTINGS_VIEW_CONTROLLER_CELL_UPDATE_LOCAL_CERTIFICATE" = "Update Local Certificate";
-"SETTINGS_VIEW_CONTROLLER_CELL_UPDATE_LOCAL_CERTIFICATE_UPDATING" = "Update Local Certificate";
-"SETTINGS_VIEW_CONTROLLER_CELL_RESET" = "Reset";
-"SETTINGS_VIEW_CONTROLLER_CELL_RESET_CONFIGURATION" = "Reset Configuration";
-"SETTINGS_VIEW_CONTROLLER_CELL_USE_CUSTOM_SERVER" = "Use Custom Server";
+"SETTINGS_VIEW_CONTROLLER_CELL_ABOUT" = "Sobre %@";
+"SETTINGS_VIEW_CONTROLLER_CELL_SUBMIT_FEEDBACK" = "Envíar tu opinión";
+"SETTINGS_VIEW_CONTROLLER_CELL_GITHUB" = "Repositorio de GitHub";
+"SETTINGS_VIEW_CONTROLLER_CELL_DISPLAY" = "Apariencia";
+"SETTINGS_VIEW_CONTROLLER_CELL_APP_ICON" = "Icono de la App";
+"SETTINGS_VIEW_CONTROLLER_CELL_CURRENT_CERTIFICATE_NOSELECTED" = "No hay certificados seleccionados";
+"SETTINGS_VIEW_CONTROLLER_CELL_ADD_CERTIFICATES" = "Añadir Certificado";
+"SETTINGS_VIEW_CONTROLLER_CELL_UPDATE_LOCAL_CERTIFICATE" = "Actualizar Certificado Local";
+"SETTINGS_VIEW_CONTROLLER_CELL_UPDATE_LOCAL_CERTIFICATE_UPDATING" = "Actualizando Certificado Local";
+"SETTINGS_VIEW_CONTROLLER_CELL_RESET" = "Reiniciar";
+"SETTINGS_VIEW_CONTROLLER_CELL_RESET_CONFIGURATION" = "Reiniciar Configuración";
+"SETTINGS_VIEW_CONTROLLER_CELL_USE_CUSTOM_SERVER" = "Usar Servidor Personalizado";
 
-"SETTINGS_VIEW_CONTROLLER_CELL_ONLINE_INSTALL_METHOD" = "Online Install Method";
+"SETTINGS_VIEW_CONTROLLER_CELL_ONLINE_INSTALL_METHOD" = "Método de Instalación en Línea";
 
 
-"SETTINGS_VIEW_CONTROLLER_CELL_EXPORT_ID" = "Export Random Identifier";
-"SETTINGS_VIEW_CONTROLLER_CELL_CHANGE_ID" = "Change Random Identifier";
+"SETTINGS_VIEW_CONTROLLER_CELL_EXPORT_ID" = "Exportar Identificador Aleatorio";
+"SETTINGS_VIEW_CONTROLLER_CELL_CHANGE_ID" = "Cambiar Identificador Aleatorio";
 
 //
-"SETTINGS_VIEW_CONTROLLER_PPQ_ALERT_TITLE" = "PPQCheck Protections";
-"SETTINGS_VIEW_CONTROLLER_PPQ_ALERT_DESCRIPTION" = "This setting enables the PPQCheck protections, which is designed to prepend each bundle identifier for the apps you sideload with a random string.\n\nThis is meant to avoid apple flagging your account by (trying) to make it so they're unable to associate the app your sideloading with one from the App Store.";
-"SETTINGS_VIEW_CONTROLLER_PPQ_ALERT_IDC" = "I don't care";
-"SETTINGS_VIEW_CONTROLLER_PPQ_ALERT_GTK" = "Good to know";
+"SETTINGS_VIEW_CONTROLLER_PPQ_ALERT_TITLE" = "Protección de PPQCheck";
+"SETTINGS_VIEW_CONTROLLER_PPQ_ALERT_DESCRIPTION" = "Este ajuste activa la protección de PPQCheck, que está diseñada para prefijar el identificador de Bundle de las Apps que sideloadeas con un texto aleatorio.\n\nEl proposito es evitar que Apple marque tu cuenta, intentando que no pueda asociar la app que sideloadeas con una del App Store.";
+"SETTINGS_VIEW_CONTROLLER_PPQ_ALERT_IDC" = "No me importa";
+"SETTINGS_VIEW_CONTROLLER_PPQ_ALERT_GTK" = "Bueno saberlo";
 
-"SETTINGS_VIEW_CONTROLLER_URL_ALERT_TITLE" = "Change Download URL";
-"SETTINGS_VIEW_CONTROLLER_CELL_CHANGE_IDENTIFIER" = "Change Random Identifier";
+"SETTINGS_VIEW_CONTROLLER_URL_ALERT_TITLE" = "Cambiar URL de Descarga";
+"SETTINGS_VIEW_CONTROLLER_CELL_CHANGE_IDENTIFIER" = "Cambiar Identificador Aleatorio";
 
 // MARK: - SettingsViewController -> AboutViewController
-"ABOUT_VIEW_CONTROLLER_SECTION_TITLE_CREDITS" = "Credits";
-"ABOUT_VIEW_CONTROLLER_SECTION_TITLE_DEVICE" = "Device";
-"ABOUT_VIEW_CONTROLLER_SECTION_TITLE_ACKNOWLEDGEMENTS" = "Acknowledgements";
+"ABOUT_VIEW_CONTROLLER_SECTION_TITLE_CREDITS" = "Créditos";
+"ABOUT_VIEW_CONTROLLER_SECTION_TITLE_DEVICE" = "Dispositivo";
+"ABOUT_VIEW_CONTROLLER_SECTION_TITLE_ACKNOWLEDGEMENTS" = "Atribuciones";
 
 
-"ABOUT_VIEW_CONTROLLER_CELL_DEVICE_VERSION" = "Device Version";
-"ABOUT_VIEW_CONTROLLER_CELL_DEVICE_ARCH" = "Architecture";
-"ABOUT_VIEW_CONTROLLER_CELL_APP_VERSION" = "App Version";
+"ABOUT_VIEW_CONTROLLER_CELL_DEVICE_VERSION" = "Versión del Dispositivo";
+"ABOUT_VIEW_CONTROLLER_CELL_DEVICE_ARCH" = "Arquitectura";
+"ABOUT_VIEW_CONTROLLER_CELL_APP_VERSION" = "Versión de la App";
 
 // MARK: - SettingsViewController -> DisplayViewController
-"DISPLAY_VIEW_CONTROLLER_SECTION_TITLE_TINT_COLOR" = "Tint Color";
-"DISPLAY_VIEW_CONTROLLER_SECTION_TITLE_APP_APPEARENCE" = "App Appearence";
+"DISPLAY_VIEW_CONTROLLER_SECTION_TITLE_TINT_COLOR" = "Color del Tinte";
+"DISPLAY_VIEW_CONTROLLER_SECTION_TITLE_APP_APPEARENCE" = "Apariencia de la App";
 
-"DISPLAY_VIEW_CONTROLLER_CELL_DEFAULT_SUBTITLE" = "Default Subtitle";
-"DISPLAY_VIEW_CONTROLLER_CELL_DEFAULT_SUBTITLE_DESCRIPTION" = "Default style for feather, hides localized description and only includes subtitle.";
+"DISPLAY_VIEW_CONTROLLER_CELL_DEFAULT_SUBTITLE" = "Subtítulo por Defecto";
+"DISPLAY_VIEW_CONTROLLER_CELL_DEFAULT_SUBTITLE_DESCRIPTION" = "Estilo por defecto de Feather, oculta la descripción localizada y solo incluye el subtítulo.";
 
-"DISPLAY_VIEW_CONTROLLER_CELL_LOCALIZED_SUBTITLE" = "Localized Subtitle";
-"DISPLAY_VIEW_CONTROLLER_CELL_LOCALIZED_SUBTITLE_DESCRIPTION" = "Replaces subtitle with app description.";
+"DISPLAY_VIEW_CONTROLLER_CELL_LOCALIZED_SUBTITLE" = "Subtítulo Localizado";
+"DISPLAY_VIEW_CONTROLLER_CELL_LOCALIZED_SUBTITLE_DESCRIPTION" = "Reemplaza el subtítulo con la descripción de la App.";
 
-"DISPLAY_VIEW_CONTROLLER_CELL_BIG_DESCRIPTION" = "Big Description";
-"DISPLAY_VIEW_CONTROLLER_CELL_BIG_DESCRIPTION_DESCRIPTION" = "Replaces screenshots with the app description.";
+"DISPLAY_VIEW_CONTROLLER_CELL_BIG_DESCRIPTION" = "Descripción Grande";
+"DISPLAY_VIEW_CONTROLLER_CELL_BIG_DESCRIPTION_DESCRIPTION" = "Reemplaza capturas de pantalla con la descripción de la App.";
 
 // MARK: - SettingsViewController -> CertificatesViewController
-"CERTIFICATES_VIEW_CONTROLLER_TITLE" = "Certificates";
+"CERTIFICATES_VIEW_CONTROLLER_TITLE" = "Certificados";
 
-"CERTIFICATES_VIEW_CONTROLLER_CELL_ADD_FOOTER" = "Supported file formats:\n\n- P12 (.p12)\n- Mobile Provision (.mobileprovision)\n\nMake sure your certificates are valid and are able to sideload to your device!";
+"CERTIFICATES_VIEW_CONTROLLER_CELL_ADD_FOOTER" = "Formatos de archivo soportados:\n\n- P12 (.p12)\n- Perfil de suministro (.mobileprovision)\n\n¡Asegúrate de que tus certificados sean válidos y puedan ser sideloadeados en tu dispositivo!";
 
-"CERTIFICATES_VIEW_CONTROLLER_CELL_ADD" = "Add Certificates";
-"CERTIFICATES_VIEW_CONTROLLER_CELL_ADD_DESCRIPTION" = "Tap to add a certificate";
+"CERTIFICATES_VIEW_CONTROLLER_CELL_ADD" = "Añadir Certificados";
+"CERTIFICATES_VIEW_CONTROLLER_CELL_ADD_DESCRIPTION" = "Toca para añadir un certificado";
 
 // MARK: - SettingsViewController -> CertificatesViewController -> Delete Alert
-"CERTIFICATES_VIEW_CONTROLLER_DELETE_ALERT_TITLE" = "You don't want to do this!";
-"CERTIFICATES_VIEW_CONTROLLER_DELETE_ALERT_DESCRIPTION" = "You're trying to delete a selected certificate, try again later when you have another certificate on hand.";
+"CERTIFICATES_VIEW_CONTROLLER_DELETE_ALERT_TITLE" = "¡No quieres hacer esto!";
+"CERTIFICATES_VIEW_CONTROLLER_DELETE_ALERT_DESCRIPTION" = "Estas intentando eliminar un certificado seleccionado, intentalo de nuevo cuando tengas otro certificado a tu disposición.";
 
 // MARK: - SettingsViewController -> CertificatesViewController -> Cell
-"CERTIFICATES_VIEW_CONTROLLER_CELL_EXPIRED" = "Expired";
-"CERTIFICATES_VIEW_CONTROLLER_CELL_DAYS_LEFT" = "%@ days left";
+"CERTIFICATES_VIEW_CONTROLLER_CELL_EXPIRED" = "Expirado";
+"CERTIFICATES_VIEW_CONTROLLER_CELL_DAYS_LEFT" = "Quedan %@ días";
 
 // MARK: - SettingsViewController -> CertificatesViewController -> CertImportingViewController
-"CERT_IMPORTING_VIEWCONTROLLER_TITLE" = "Import";
+"CERT_IMPORTING_VIEWCONTROLLER_TITLE" = "Importar";
 "CERT_IMPORTING_VIEWCONTROLLER_SECTION_PROVISIONING" = "";
 
 // MARK: - SettingsViewController -> CertificatesViewController -> CertImportingViewController -> Password Alert
 
-"CERT_IMPORTING_VIEWCONTROLLER_PW_ALERT_TITLE" = "Bad Password";
-"CERT_IMPORTING_VIEWCONTROLLER_PW_ALERT_DESCRIPTION" = "Please check the password and try again.";
+"CERT_IMPORTING_VIEWCONTROLLER_PW_ALERT_TITLE" = "Contraseña Inválida";
+"CERT_IMPORTING_VIEWCONTROLLER_PW_ALERT_DESCRIPTION" = "Por favor revise la contraseña e inténtelo de nuevo.";
 
-"CERT_IMPORTING_VIEWCONTROLLER_CELL_IMPORT_PROV" = "Import Provisioning File";
-"CERT_IMPORTING_VIEWCONTROLLER_CELL_IMPORT_CERT" = "Import Certificate File";
-"CERT_IMPORTING_VIEWCONTROLLER_CELL_IMPORT_ENTER_PW" = "Enter Password";
-"CERT_IMPORTING_VIEWCONTROLLER_CELL_IMPORT_PW" = "Password";
+"CERT_IMPORTING_VIEWCONTROLLER_CELL_IMPORT_PROV" = "Importar Archivo de Suministro";
+"CERT_IMPORTING_VIEWCONTROLLER_CELL_IMPORT_CERT" = "Importar Archivo de Certificado";
+"CERT_IMPORTING_VIEWCONTROLLER_CELL_IMPORT_ENTER_PW" = "Introducir Contraseña";
+"CERT_IMPORTING_VIEWCONTROLLER_CELL_IMPORT_PW" = "Contraseña";
 
-"CERT_IMPORTING_VIEWCONTROLLER_FOOTER_PROV" = "Import a provisioning file to be able to sideload to your device.";
-"CERT_IMPORTING_VIEWCONTROLLER_FOOTER_CERT" = "Import a file containing a valid certificate.";
-"CERT_IMPORTING_VIEWCONTROLLER_FOOTER_PASS" = "Enter the password associated with the private key, leave it blank if theres no password required.";
+"CERT_IMPORTING_VIEWCONTROLLER_FOOTER_PROV" = "Importe un archivo de suministro para poder sideloadear a tu dispositivo.";
+"CERT_IMPORTING_VIEWCONTROLLER_FOOTER_CERT" = "Importe un archivo que contenga un certificado válido.";
+"CERT_IMPORTING_VIEWCONTROLLER_FOOTER_PASS" = "Introduzca la contraseña asociada a la llave privada, déjalo en blanco si una contraseña no es necesaria.";
 
 // MARK: - SettingsViewController -> ResetViewController
-"RESET_VIEW_CONTROLLER_CLEAR_CACHE" = "Clear Network Cache";
-"RESET_VIEW_CONTROLLER_CLEAR_CACHE_ALERT_TITLE" = "This action is irreversible. Cached network requests and images will be cleared.";
+"RESET_VIEW_CONTROLLER_CLEAR_CACHE" = "Borrar Cache de Red";
+"RESET_VIEW_CONTROLLER_CLEAR_CACHE_ALERT_TITLE" = "Esta acción es irreversible. Peticiones de Red e imágenes cacheadas serán eliminados.";
 
 // MARK: - Donation
-"DONATION_TITLE" = "Donate";
-"DONATION_DONATIONS" = "Donations";
+"DONATION_TITLE" = "Donar";
+"DONATION_DONATIONS" = "Donaciones";
 
-"DONATION_CELL_1_TITLE" = "Secret Repo";
-"DONATION_CELL_1_DESCRIPTION" = "Get access to our secret repo by donating, will provide you with beta access to Feather.";
+"DONATION_CELL_1_TITLE" = "Repo Secreta";
+"DONATION_CELL_1_DESCRIPTION" = "Dona para obtener acceso a nuestra repo secreta, que te dará acceso anticipado a Feather.";
 
-"DONATION_CELL_2_TITLE" = "Show Your Support";
-"DONATION_CELL_2_DESCRIPTION" = "Show your support by donating! If you're unable to donate, spreading the word about Feather works too!";
+"DONATION_CELL_2_TITLE" = "Muestra tu Soporte";
+"DONATION_CELL_2_DESCRIPTION" = "¡Muestra tu soporte donando! Si no eres capaz de donar, hacer correr la voz sobre Feather también funciona";


### PR DESCRIPTION
List of strings I'm not completely sure I properly translated:
- `"CERTIFICATES_VIEW_CONTROLLER_CELL_ADD_FOOTER"`: All good except "Mobile Provision" which I translated as "Perfil de suministro" which translates back as "Provisioning profile", I did this change because the official Apple docs (https://developer.apple.com/help/account/manage-provisioning-profiles/edit-download-or-delete-profiles/) label `.mobileprovision` as such in their Spanish translation.
- `"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_DELETE_PLACEHOLDER_WATCH_APP"`: I'm not sure if there's a Spanish equivalent of Placeholder in this case
- `"DISPLAY_VIEW_CONTROLLER_CELL_BIG_DESCRIPTION_DESCRIPTION"`: Screenshot has a different translation based on context, my assumption is that the context is as in taking a screenshot of your device screen