### PR TITLE
Fix URL Predication/Regex in SettingsViewController.swift

### DIFF
--- a/iOS/Views/Settings/SettingsViewController.swift
+++ b/iOS/Views/Settings/SettingsViewController.swift
@@ -384,7 +384,7 @@ extension SettingsViewController {
 	}
 
 	func isValidURL(_ url: String) -> Bool {
-		let urlPredicate = NSPredicate(format: "SELF MATCHES %@", "https?://$")
+		let urlPredicate = NSPredicate(format: "SELF MATCHES %@", "https://.+")
 		return urlPredicate.evaluate(with: url)
 	}
 }


### PR DESCRIPTION
`urlPredicate` was set to match only `https://` and `http://`, it didn't allow for a URL to be entered. 

This should allow for the URL to be fully entered/saved

It also limits it to just `https` urls, since that is apparently require by iOS 18+ anyways

Should fix issue #73