### PR TITLE
feat: Allow Automatic Installation of App After Signing

### DIFF
--- a/Shared/Data/UserDefaults/Preferences.swift
+++ b/Shared/Data/UserDefaults/Preferences.swift
@@ -44,6 +44,9 @@ enum Preferences {
 	
 	@Storage(key: "Feather.fuckOffPpqcheckDetection", defaultValue: true)
 	static var isFuckingPPqcheckDetectionOff: Bool
+    
+	@Storage(key: "Feather.autoInstallAfterSign", defaultValue: false)
+	static var autoInstallAfterSign: Bool
 	
 	@Storage(key: "Feather.CertificateTitleAppIDtoTeamID", defaultValue: false)
 	static var certificateTitleAppIDtoTeamID: Bool

--- a/iOS/Views/Apps/LibraryViewController.swift
+++ b/iOS/Views/Apps/LibraryViewController.swift
@@ -188,11 +188,15 @@ extension LibraryViewController {
 				popupVC = PopupViewController()
 				popupVC.modalPresentationStyle = .pageSheet
 				
-				let button1 = PopupViewControllerButton(title: "Sign \((source!.value(forKey: "name") as? String ?? ""))", color: .tintColor.withAlphaComponent(0.9))
+				let button1 = PopupViewControllerButton(
+					title: Preferences.autoInstallAfterSign
+					? "Sign & Install \((source!.value(forKey: "name") as? String ?? ""))"
+					: "Sign \((source!.value(forKey: "name") as? String ?? ""))",
+					color: .tintColor.withAlphaComponent(0.9))
 				button1.onTap = { [weak self] in
 					guard let self = self else { return }
 					self.popupVC.dismiss(animated: true)
-					self.startSigning(meow: source!)
+					self.startSigning(meow: source!, filePath: filePath?.path ?? "")
 				}
 				
 				let button2 = PopupViewControllerButton(title: "Install \((source!.value(forKey: "name") as? String ?? ""))", color: .quaternarySystemFill, titleColor: .tintColor)
@@ -243,9 +247,9 @@ extension LibraryViewController {
 		tableView.deselectRow(at: indexPath, animated: true)
 	}
 	
-	@objc func startSigning(meow: NSManagedObject) {
+	@objc func startSigning(meow: NSManagedObject, filePath: String) {
 		if FileManager.default.fileExists(atPath: CoreDataManager.shared.getFilesForDownloadedApps(for:(meow as! DownloadedApps)).path) {
-			let ap = AppSigningViewController(app: meow, appsViewController: self)
+			let ap = AppSigningViewController(app: meow, filePath: filePath, appsViewController: self)
 			let navigationController = UINavigationController(rootViewController: ap)
 			navigationController.modalPresentationStyle = .fullScreen
 			DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/iOS/Views/Apps/Signing/AppSigningViewController.swift
+++ b/iOS/Views/Apps/Signing/AppSigningViewController.swift
@@ -28,6 +28,7 @@ class AppSigningViewController: UITableViewController, UINavigationControllerDel
 	var removeInjectPaths: [String] = []
 	
     var app: NSManagedObject!
+    var filePath: String = ""
     var name: String = "Unknown"
     var bundleId: String = "unknown"
     var version: String = "unknown"
@@ -55,9 +56,10 @@ class AppSigningViewController: UITableViewController, UINavigationControllerDel
 	
 	var certs: Certificate?
     
-    init(app: NSManagedObject, appsViewController: LibraryViewController) {
+    init(app: NSManagedObject, filePath: String, appsViewController: LibraryViewController) {
         self.appsViewController = appsViewController
         self.app = app
+        self.filePath = filePath
         super.init(style: .insetGrouped)
 		
 		if let hasGotCert = CoreDataManager.shared.getCurrentCertificate() {
@@ -176,6 +178,9 @@ class AppSigningViewController: UITableViewController, UINavigationControllerDel
 			if success {
 				self.appsViewController.fetchSources()
 				self.appsViewController.tableView.reloadData()
+                if Preferences.autoInstallAfterSign {
+                    self.appsViewController.startInstallProcess(meow: self.app, filePath: self.filePath)
+                }
 			}
 			self.dismiss(animated: true)
 		}

--- a/iOS/Views/Settings/SettingsViewController.swift
+++ b/iOS/Views/Settings/SettingsViewController.swift
@@ -16,7 +16,7 @@ class SettingsViewController: UITableViewController {
 		["Donate"],
 		[String.localized("SETTINGS_VIEW_CONTROLLER_CELL_ABOUT", arguments: "Feather"), String.localized("SETTINGS_VIEW_CONTROLLER_CELL_SUBMIT_FEEDBACK"), String.localized("SETTINGS_VIEW_CONTROLLER_CELL_GITHUB")],
 		[String.localized("SETTINGS_VIEW_CONTROLLER_CELL_DISPLAY"), String.localized("SETTINGS_VIEW_CONTROLLER_CELL_APP_ICON")],
-		["Current Certificate", String.localized("SETTINGS_VIEW_CONTROLLER_CELL_ADD_CERTIFICATES")],
+		["Current Certificate", String.localized("SETTINGS_VIEW_CONTROLLER_CELL_ADD_CERTIFICATES"), "Auto Install"],
 //		["Signing Configuration"],
 		["Fuck PPQCheck", "PPQCheckMitigationString", "PPQCheckMitigationExport"],
 		["Use Server", String.localized("SETTINGS_VIEW_CONTROLLER_CELL_USE_CUSTOM_SERVER")],
@@ -142,6 +142,13 @@ extension SettingsViewController {
 				cell.textLabel?.textColor = .secondaryLabel
 				cell.selectionStyle = .none
 			}
+		case "Auto Install":
+			let autoInstall = SwitchViewCell()
+			autoInstall.textLabel?.text = "Install after signing"
+			autoInstall.switchControl.addTarget(self, action: #selector(autoInstallAfterSignToggled(_:)), for: .valueChanged)
+			autoInstall.switchControl.isOn = Preferences.autoInstallAfterSign
+			autoInstall.selectionStyle = .none
+			return autoInstall
 		case "Fuck PPQCheck":
 			let fuckPPq = SwitchViewCell()
 			fuckPPq.textLabel?.text = String.localized("SETTINGS_VIEW_CONTROLLER_PPQ_ALERT_TITLE")
@@ -236,6 +243,10 @@ extension SettingsViewController {
 	
 	@objc func fuckPpqcheckToggled(_ sender: UISwitch) {
 		Preferences.isFuckingPPqcheckDetectionOff = sender.isOn
+	}
+    
+	@objc func autoInstallAfterSignToggled(_ sender: UISwitch) {
+		Preferences.autoInstallAfterSign = sender.isOn
 	}
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/iOS/Views/Settings/SettingsViewController.swift
+++ b/iOS/Views/Settings/SettingsViewController.swift
@@ -16,9 +16,9 @@ class SettingsViewController: UITableViewController {
 		["Donate"],
 		[String.localized("SETTINGS_VIEW_CONTROLLER_CELL_ABOUT", arguments: "Feather"), String.localized("SETTINGS_VIEW_CONTROLLER_CELL_SUBMIT_FEEDBACK"), String.localized("SETTINGS_VIEW_CONTROLLER_CELL_GITHUB")],
 		[String.localized("SETTINGS_VIEW_CONTROLLER_CELL_DISPLAY"), String.localized("SETTINGS_VIEW_CONTROLLER_CELL_APP_ICON")],
-		["Current Certificate", String.localized("SETTINGS_VIEW_CONTROLLER_CELL_ADD_CERTIFICATES"), "Auto Install"],
+		["Current Certificate", String.localized("SETTINGS_VIEW_CONTROLLER_CELL_ADD_CERTIFICATES")],
 //		["Signing Configuration"],
-		["Fuck PPQCheck", "PPQCheckMitigationString", "PPQCheckMitigationExport"],
+		["Auto Install", "Fuck PPQCheck", "PPQCheckMitigationString", "PPQCheckMitigationExport"],
 		["Use Server", String.localized("SETTINGS_VIEW_CONTROLLER_CELL_USE_CUSTOM_SERVER")],
 		[String.localized("SETTINGS_VIEW_CONTROLLER_CELL_UPDATE_LOCAL_CERTIFICATE")],
 		[


### PR DESCRIPTION
Allow Automatic Installation of App After Signing

---

### **Description:**

This pull request introduces a new feature that allows users to automatically install an app once it has been signed. Previously, users were required to manually install the app after signing. This enhancement improves the user experience by automating that process.

### **Changes Introduced:**
- Users can now check a toggle to allow automatic install after signing in options.
![2024-10-03 at 15 46 03](https://github.com/user-attachments/assets/280d2f94-ae79-4efc-a51e-87e735821e27)



  
### **Idea Reference:**
- https://github.com/khcrysalis/Feather/issues/86
