### PR TITLE
Feature/multi select deletion + library tabbed UI

### DIFF
--- a/Shared/Localizations/en.lproj/Localizable.strings
+++ b/Shared/Localizations/en.lproj/Localizable.strings
@@ -226,7 +226,7 @@
 "APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_URLSCHEME_DESCRIPTION" = "Removes any possible URL schemes (i.e. 'feather://')";
 
 "APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_ALLOW_BROWSING_DOCUMENTS" = "Allow Browsing Documents";
-"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_ALLOW_BROWSING_DOCUMENTS_DESCRIPTION" = "Allows other apps to open and edit the files stored in the Documents folder. This option also lets users set the app’s default save location in Settings.";
+"APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_ALLOW_BROWSING_DOCUMENTS_DESCRIPTION" = "Allows other apps to open and edit the files stored in the Documents folder. This option also lets users set the app's default save location in Settings.";
 
 "APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_ALLOW_ITUNES_SHARING" = "Allow iTunes Sharing";
 "APP_SIGNING_INPUT_VIEW_CONTROLLER_REMOVE_ALLOW_ITUNES_SHARING_DESCRIPTION" = "Forces the app to share their documents directory, allowing sharing between iTunes and Finder.";
@@ -275,6 +275,11 @@
 "LIBRARY_VIEW_CONTROLLER_SIGN_ACTION_OPEN_LN_FILES" = "Open in Files";
 "LIBRARY_VIEW_CONTROLLER_SIGN_ACTION_INSTALL_CONFIRM" = "Confirm Installation";
 "LIBRARY_VIEW_CONTROLLER_SIGN_ACTION_INSTALL_CONFIRM_DESCRIPTION" = "Trying to install via the downloaded apps tab may not work as they are most likely not signed! It's recommended you sign that application first before installing.";
+
+// MARK: - Multi-Select Deletion
+"EDIT" = "Edit";
+"DELETE_SELECTED_ITEMS" = "Delete Selected Items";
+"DELETE_SELECTED_ITEMS_CONFIRMATION" = "Are you sure you want to delete %@ selected items? This cannot be undone.";
 
 // MARK: - SettingsViewController
 // Headers

--- a/iOS/Views/Apps/LibraryViewController.swift
+++ b/iOS/Views/Apps/LibraryViewController.swift
@@ -23,6 +23,13 @@ class LibraryViewController: UITableViewController {
 	var popupVC: PopupViewController!
 	var loaderAlert: UIAlertController?
 	
+	// Properties for multi-select deletion
+	private var isEditingMode = false
+	private var selectedItems: Set<IndexPath> = []
+	private var editBarButtonItem: UIBarButtonItem!
+	private var deleteBarButtonItem: UIBarButtonItem!
+	private var cancelBarButtonItem: UIBarButtonItem!
+	
 	init() { super.init(style: .grouped) }
 	required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 	
@@ -84,6 +91,16 @@ class LibraryViewController: UITableViewController {
 	fileprivate func setupNavigation() {
 		self.navigationController?.navigationBar.prefersLargeTitles = true
 		self.title = String.localized("TAB_LIBRARY")
+		
+		// Initialize bar button items for editing mode
+		editBarButtonItem = UIBarButtonItem(title: String.localized("EDIT"), style: .plain, target: self, action: #selector(toggleEditingMode))
+		deleteBarButtonItem = UIBarButtonItem(title: String.localized("DELETE"), style: .plain, target: self, action: #selector(deleteSelectedItems))
+		deleteBarButtonItem.tintColor = .systemRed
+		deleteBarButtonItem.isEnabled = false
+		cancelBarButtonItem = UIBarButtonItem(title: String.localized("CANCEL"), style: .plain, target: self, action: #selector(toggleEditingMode))
+		
+		// Set the initial right bar button item
+		navigationItem.rightBarButtonItem = editBarButtonItem
 	}
 	
 	private func handleAppUpdate(for signedApp: SignedApps) {
@@ -96,7 +113,8 @@ class LibraryViewController: UITableViewController {
 		
 		present(loaderAlert!, animated: true)
 		
-		#if DEBUG
+		// Create mock source if in debug mode
+		if isDebugMode {
 			let mockSource = SourceRefreshOperation()
 			mockSource.createMockSource { mockSourceData in
 				if let sourceData = mockSourceData {
@@ -108,7 +126,8 @@ class LibraryViewController: UITableViewController {
 					}
 				}
 			}
-		#else
+		} else {
+			// Normal source fetch
 			SourceGET().downloadURL(from: sourceURL) { [weak self] result in
 				guard let self = self else { return }
 				
@@ -129,7 +148,7 @@ class LibraryViewController: UITableViewController {
 					}
 				}
 			}
-		#endif
+		}
 	}
 	
 	private func handleSourceData(_ sourceData: SourcesData, for signedApp: SignedApps) {
@@ -215,6 +234,15 @@ class LibraryViewController: UITableViewController {
 			self.loaderAlert?.dismiss(animated: true)
 		}
 	}
+	
+	private var isDebugMode: Bool {
+		var isDebug = false
+		assert({
+			isDebug = true
+			return true
+		}())
+		return isDebug
+	}
 }
 
 extension LibraryViewController {
@@ -257,11 +285,24 @@ extension LibraryViewController {
 	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 		let cell = AppsTableViewCell(style: .subtitle, reuseIdentifier: "RoundedBackgroundCell")
 		cell.selectionStyle = .default
-		cell.accessoryType = .disclosureIndicator
+		cell.accessoryType = isEditingMode ? .none : .disclosureIndicator
 		cell.backgroundColor = .clear
+		
 		let source = getApplication(row: indexPath.row, section: indexPath.section)
 		let filePath = getApplicationFilePath(with: source!, row: indexPath.row, section: indexPath.section)
 		
+		// Configure checkbox for editing mode
+		if isEditingMode {
+			if selectedItems.contains(indexPath) {
+				cell.accessoryView = UIImageView(image: UIImage(systemName: "checkmark.circle.fill"))
+				cell.accessoryView?.tintColor = .systemBlue
+			} else {
+				cell.accessoryView = UIImageView(image: UIImage(systemName: "circle"))
+				cell.accessoryView?.tintColor = .systemGray3
+			}
+		} else {
+			cell.accessoryView = nil
+		}
 		
 		if let iconURL = source!.value(forKey: "iconURL") as? String {
 			let imagePath = filePath!.appendingPathComponent(iconURL)
@@ -280,6 +321,13 @@ extension LibraryViewController {
 	}
 	
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		// Handle selection for editing mode
+		if isEditingMode {
+			toggleItemSelection(at: indexPath)
+			tableView.deselectRow(at: indexPath, animated: true)
+			return
+		}
+		
 		let source = getApplication(row: indexPath.row, section: indexPath.section)
 		let filePath = getApplicationFilePath(with: source!, row: indexPath.row, section: indexPath.section, getuuidonly: true)
 		let filePath2 = getApplicationFilePath(with: source!, row: indexPath.row, section: indexPath.section, getuuidonly: false)
@@ -485,30 +533,26 @@ extension LibraryViewController {
 	}
 	
 	override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+		// Disable swipe actions when in editing mode
+		if isEditingMode {
+			return nil
+		}
+		
 		let source = getApplication(row: indexPath.row, section: indexPath.section)
 		
 		let deleteAction = UIContextualAction(style: .destructive, title: String.localized("DELETE")) { (action, view, completionHandler) in
 			switch indexPath.section {
 			case 0:
-				if self.isFiltering {
-					self.filteredSignedApps.remove(at: indexPath.row)
-				} else {
-					self.signedApps?.remove(at: indexPath.row)
-				}
 				CoreDataManager.shared.deleteAllSignedAppContent(for: source! as! SignedApps)
+				self.signedApps?.remove(at: indexPath.row)
+				self.tableView.reloadSections(IndexSet(integer: 0), with: .automatic)
 			case 1:
-				if self.isFiltering {
-					self.filteredDownloadedApps.remove(at: indexPath.row)
-				} else {
-					self.downloadedApps?.remove(at: indexPath.row)
-				}
 				CoreDataManager.shared.deleteAllDownloadedAppContent(for: source! as! DownloadedApps)
+				self.downloadedApps?.remove(at: indexPath.row)
+				self.tableView.reloadSections(IndexSet(integer: 1), with: .automatic)
 			default:
 				break
 			}
-			
-			self.fetchSources()
-			
 			completionHandler(true)
 		}
 		
@@ -577,6 +621,97 @@ extension LibraryViewController {
 				self.tableView.reloadData()
 			}
 		}
+	}
+	
+	// MARK: - Multi-select Methods
+	
+	@objc private func toggleEditingMode() {
+		isEditingMode = !isEditingMode
+		selectedItems.removeAll()
+		
+		if isEditingMode {
+			navigationItem.rightBarButtonItems = [cancelBarButtonItem, deleteBarButtonItem]
+		} else {
+			navigationItem.rightBarButtonItem = editBarButtonItem
+		}
+		
+		deleteBarButtonItem.isEnabled = !selectedItems.isEmpty
+		tableView.reloadData()
+	}
+	
+	@objc private func deleteSelectedItems() {
+		guard !selectedItems.isEmpty else { return }
+		
+		let alert = UIAlertController(
+			title: String.localized("DELETE_SELECTED_ITEMS"),
+			message: String.localized("DELETE_SELECTED_ITEMS_CONFIRMATION", arguments: String(selectedItems.count)),
+			preferredStyle: .alert
+		)
+		
+		let confirmAction = UIAlertAction(title: String.localized("DELETE"), style: .destructive) { [weak self] _ in
+			guard let self = self else { return }
+			
+			// Sort by section and row in descending order to avoid index issues when removing items
+			let sortedIndexPaths = self.selectedItems.sorted { 
+				if $0.section == $1.section {
+					return $0.row > $1.row
+				}
+				return $0.section > $1.section
+			}
+			
+			// Process deletions by section
+			var deletedInSection0 = false
+			var deletedInSection1 = false
+			
+			for indexPath in sortedIndexPaths {
+				let source = self.getApplication(row: indexPath.row, section: indexPath.section)
+				
+				switch indexPath.section {
+				case 0:
+					CoreDataManager.shared.deleteAllSignedAppContent(for: source! as! SignedApps)
+					self.signedApps?.remove(at: indexPath.row)
+					deletedInSection0 = true
+				case 1:
+					CoreDataManager.shared.deleteAllDownloadedAppContent(for: source! as! DownloadedApps)
+					self.downloadedApps?.remove(at: indexPath.row)
+					deletedInSection1 = true
+				default:
+					break
+				}
+			}
+			
+			// Reload appropriate sections
+			var indexSet = IndexSet()
+			if deletedInSection0 {
+				indexSet.insert(0)
+			}
+			if deletedInSection1 {
+				indexSet.insert(1)
+			}
+			
+			self.tableView.reloadSections(indexSet, with: .automatic)
+			
+			// Exit editing mode
+			self.toggleEditingMode()
+		}
+		
+		let cancelAction = UIAlertAction(title: String.localized("CANCEL"), style: .cancel)
+		
+		alert.addAction(confirmAction)
+		alert.addAction(cancelAction)
+		
+		present(alert, animated: true)
+	}
+	
+	private func toggleItemSelection(at indexPath: IndexPath) {
+		if selectedItems.contains(indexPath) {
+			selectedItems.remove(indexPath)
+		} else {
+			selectedItems.insert(indexPath)
+		}
+		
+		deleteBarButtonItem.isEnabled = !selectedItems.isEmpty
+		tableView.reloadRows(at: [indexPath], with: .none)
 	}
 	
 	func getApplicationFilePath(with app: NSManagedObject, row: Int, section:Int, getuuidonly: Bool = false) -> URL? {

--- a/iOS/Views/Apps/LibraryViewController.swift
+++ b/iOS/Views/Apps/LibraryViewController.swift
@@ -136,7 +136,7 @@ class LibraryViewController: UITableViewController {
 		cancelBarButtonItem = UIBarButtonItem(title: String.localized("CANCEL"), style: .plain, target: self, action: #selector(toggleEditingMode))
 		
 		// Set the initial right bar button item
-		navigationItem.rightBarButtonItem = editBarButtonItem
+		navigationItem.rightBarButtonItems = [editBarButtonItem]
 	}
 	
 	private func handleAppUpdate(for signedApp: SignedApps) {
@@ -675,7 +675,7 @@ extension LibraryViewController {
 		if isEditingMode {
 			navigationItem.rightBarButtonItems = [cancelBarButtonItem, deleteBarButtonItem]
 		} else {
-			navigationItem.rightBarButtonItem = editBarButtonItem
+			navigationItem.rightBarButtonItems = [editBarButtonItem]
 		}
 		
 		deleteBarButtonItem.isEnabled = !selectedItems.isEmpty

--- a/iOS/Views/Apps/LibraryViewController.swift
+++ b/iOS/Views/Apps/LibraryViewController.swift
@@ -30,6 +30,14 @@ class LibraryViewController: UITableViewController {
 	private var deleteBarButtonItem: UIBarButtonItem!
 	private var cancelBarButtonItem: UIBarButtonItem!
 	
+	// Tab selection
+	private var segmentedControl: UISegmentedControl!
+	private enum LibraryTab: Int {
+		case downloaded = 0
+		case signed = 1
+	}
+	private var selectedTab: LibraryTab = .downloaded
+	
 	init() { super.init(style: .grouped) }
 	required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 	
@@ -37,6 +45,7 @@ class LibraryViewController: UITableViewController {
 		super.viewDidLoad()
 		setupViews()
 		setupSearchController()
+		setupSegmentedControl()
 		fetchSources()
 		loaderAlert = presentLoader()
 	}
@@ -57,6 +66,33 @@ class LibraryViewController: UITableViewController {
 			name: Notification.Name("InstallDownloadedApp"),
 			object: nil
 		)
+	}
+	
+	fileprivate func setupSegmentedControl() {
+		segmentedControl = UISegmentedControl(items: [
+			String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_DOWNLOADED_APPS"),
+			String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_TITLE_SIGNED_APPS")
+		])
+		segmentedControl.selectedSegmentIndex = selectedTab.rawValue
+		segmentedControl.addTarget(self, action: #selector(segmentChanged(_:)), for: .valueChanged)
+		
+		// Add the segmented control to a container view to add proper padding
+		let containerView = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 50))
+		segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+		containerView.addSubview(segmentedControl)
+		
+		NSLayoutConstraint.activate([
+			segmentedControl.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+			segmentedControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+			segmentedControl.centerYAnchor.constraint(equalTo: containerView.centerYAnchor)
+		])
+		
+		tableView.tableHeaderView = containerView
+	}
+	
+	@objc private func segmentChanged(_ sender: UISegmentedControl) {
+		selectedTab = LibraryTab(rawValue: sender.selectedSegmentIndex) ?? .downloaded
+		tableView.reloadData()
 	}
 	
 	@objc private func handleInstallNotification(_ notification: Notification) {
@@ -246,62 +282,62 @@ class LibraryViewController: UITableViewController {
 }
 
 extension LibraryViewController {
-	override func numberOfSections(in tableView: UITableView) -> Int { return 2 }
+	override func numberOfSections(in tableView: UITableView) -> Int { return 1 }
 	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-		switch section {
-		case 0:
+		switch selectedTab {
+		case .signed:
 			return isFiltering ? filteredSignedApps.count : signedApps?.count ?? 0
-		case 1:
+		case .downloaded:
 			return isFiltering ? filteredDownloadedApps.count : downloadedApps?.count ?? 0
-		default:
-			return 0
 		}
 	}
 	
 	override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-		switch section {
-		case 0:
-			let headerWithButton = GroupedSectionHeader(
+		switch selectedTab {
+		case .signed:
+			let headerView = GroupedSectionHeader(
                 title: String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_TITLE_SIGNED_APPS"),
-				subtitle: String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_TITLE_SIGNED_APPS_TOTAL", arguments: String(signedApps?.count ?? 0)),
-                buttonTitle: String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_BUTTON_IMPORT"),
-                buttonAction: {
-				self.startImporting()
-			})
-			return headerWithButton
-		case 1:
-			
+				subtitle: String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_TITLE_SIGNED_APPS_TOTAL", arguments: String(signedApps?.count ?? 0))
+			)
+			return headerView
+		case .downloaded:
 			let headerWithButton = GroupedSectionHeader(
 				title: String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_DOWNLOADED_APPS"),
-				subtitle: String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_TITLE_DOWNLOADED_APPS_TOTAL", arguments: String(downloadedApps?.count ?? 0))
+				subtitle: String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_TITLE_DOWNLOADED_APPS_TOTAL", arguments: String(downloadedApps?.count ?? 0)),
+                buttonTitle: String.localized("LIBRARY_VIEW_CONTROLLER_SECTION_BUTTON_IMPORT"),
+                buttonAction: {
+					self.startImporting()
+				}
 			)
-			
 			return headerWithButton
-		default:
-			return nil
 		}
 	}
 	
 	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 		let cell = AppsTableViewCell(style: .subtitle, reuseIdentifier: "RoundedBackgroundCell")
 		cell.selectionStyle = .default
-		cell.accessoryType = isEditingMode ? .none : .disclosureIndicator
+		cell.accessoryType = .none
 		cell.backgroundColor = .clear
 		
-		let source = getApplication(row: indexPath.row, section: indexPath.section)
-		let filePath = getApplicationFilePath(with: source!, row: indexPath.row, section: indexPath.section)
+		let source = getApplicationForTab(row: indexPath.row)
+		let section = selectedTab == .signed ? 0 : 1
+		let filePath = getApplicationFilePath(with: source!, row: indexPath.row, section: section)
 		
 		// Configure checkbox for editing mode
 		if isEditingMode {
-			if selectedItems.contains(indexPath) {
-				cell.accessoryView = UIImageView(image: UIImage(systemName: "checkmark.circle.fill"))
-				cell.accessoryView?.tintColor = .systemBlue
-			} else {
-				cell.accessoryView = UIImageView(image: UIImage(systemName: "circle"))
-				cell.accessoryView?.tintColor = .systemGray3
-			}
+			// Create an appropriate accessory view for edit mode
+			let actualIndexPath = IndexPath(row: indexPath.row, section: section)
+			let isSelected = selectedItems.contains(actualIndexPath)
+			let imageName = isSelected ? "checkmark.circle.fill" : "circle"
+			let accessoryImage = UIImage(systemName: imageName)
+			let accessoryImageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 29, height: 29))
+			accessoryImageView.image = accessoryImage
+			accessoryImageView.tintColor = isSelected ? .systemBlue : .systemGray3
+			cell.accessoryView = accessoryImageView
 		} else {
+			// Reset to normal mode
 			cell.accessoryView = nil
+			cell.accessoryType = .disclosureIndicator
 		}
 		
 		if let iconURL = source!.value(forKey: "iconURL") as? String {
@@ -323,16 +359,21 @@ extension LibraryViewController {
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		// Handle selection for editing mode
 		if isEditingMode {
-			toggleItemSelection(at: indexPath)
+			// Convert to the actual indexPath for the selected items set
+			let section = selectedTab == .signed ? 0 : 1
+			let actualIndexPath = IndexPath(row: indexPath.row, section: section)
+			toggleItemSelection(at: actualIndexPath)
 			tableView.deselectRow(at: indexPath, animated: true)
 			return
 		}
 		
-		let source = getApplication(row: indexPath.row, section: indexPath.section)
-		let filePath = getApplicationFilePath(with: source!, row: indexPath.row, section: indexPath.section, getuuidonly: true)
-		let filePath2 = getApplicationFilePath(with: source!, row: indexPath.row, section: indexPath.section, getuuidonly: false)
+		let section = selectedTab == .signed ? 0 : 1
+		let source = getApplicationForTab(row: indexPath.row)
+		
+		let filePath = getApplicationFilePath(with: source!, row: indexPath.row, section: section, getuuidonly: true)
+		let filePath2 = getApplicationFilePath(with: source!, row: indexPath.row, section: section, getuuidonly: false)
 		let appName = "\((source!.value(forKey: "name") as? String ?? ""))"
-		switch indexPath.section {
+		switch section {
 		case 0:
 			if FileManager.default.fileExists(atPath: filePath2!.path) {
 				popupVC = PopupViewController()
@@ -538,18 +579,19 @@ extension LibraryViewController {
 			return nil
 		}
 		
-		let source = getApplication(row: indexPath.row, section: indexPath.section)
+		let section = selectedTab == .signed ? 0 : 1
+		let source = getApplicationForTab(row: indexPath.row)
 		
 		let deleteAction = UIContextualAction(style: .destructive, title: String.localized("DELETE")) { (action, view, completionHandler) in
-			switch indexPath.section {
+			switch section {
 			case 0:
 				CoreDataManager.shared.deleteAllSignedAppContent(for: source! as! SignedApps)
 				self.signedApps?.remove(at: indexPath.row)
-				self.tableView.reloadSections(IndexSet(integer: 0), with: .automatic)
+				self.tableView.reloadData()
 			case 1:
 				CoreDataManager.shared.deleteAllDownloadedAppContent(for: source! as! DownloadedApps)
 				self.downloadedApps?.remove(at: indexPath.row)
-				self.tableView.reloadSections(IndexSet(integer: 1), with: .automatic)
+				self.tableView.reloadData()
 			default:
 				break
 			}
@@ -564,8 +606,9 @@ extension LibraryViewController {
 	}
 	
 	override func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-		let source = getApplication(row: indexPath.row, section: indexPath.section)
-		let filePath = getApplicationFilePath(with: source!, row: indexPath.row, section: indexPath.section)
+		let section = selectedTab == .signed ? 0 : 1
+		let source = getApplicationForTab(row: indexPath.row)
+		let filePath = getApplicationFilePath(with: source!, row: indexPath.row, section: section)
 		
 		let configuration = UIContextMenuConfiguration(identifier: nil, actionProvider: { _ in
 			return UIMenu(title: "", image: nil, identifier: nil, options: [], children: [
@@ -606,7 +649,7 @@ extension LibraryViewController {
 		return configuration
 	}
 	
-	
+
 }
 
 extension LibraryViewController {
@@ -680,16 +723,8 @@ extension LibraryViewController {
 				}
 			}
 			
-			// Reload appropriate sections
-			var indexSet = IndexSet()
-			if deletedInSection0 {
-				indexSet.insert(0)
-			}
-			if deletedInSection1 {
-				indexSet.insert(1)
-			}
-			
-			self.tableView.reloadSections(indexSet, with: .automatic)
+			// Reload the table view for the current tab
+			self.tableView.reloadData()
 			
 			// Exit editing mode
 			self.toggleEditingMode()
@@ -711,7 +746,10 @@ extension LibraryViewController {
 		}
 		
 		deleteBarButtonItem.isEnabled = !selectedItems.isEmpty
-		tableView.reloadRows(at: [indexPath], with: .none)
+		
+		// Since we're using a single section in the table view now,
+		// we need to use section 0 for the reload
+		tableView.reloadRows(at: [IndexPath(row: indexPath.row, section: 0)], with: .none)
 	}
 	
 	func getApplicationFilePath(with app: NSManagedObject, row: Int, section:Int, getuuidonly: Bool = false) -> URL? {
@@ -755,7 +793,25 @@ extension LibraryViewController {
 		}
 		return nil
 	}
-
+	
+	/// Gets the application based on the currently selected tab and row
+	func getApplicationForTab(row: Int) -> NSManagedObject? {
+		if isFiltering {
+			switch selectedTab {
+			case .signed:
+				return row < filteredSignedApps.count ? filteredSignedApps[row] : nil
+			case .downloaded:
+				return row < filteredDownloadedApps.count ? filteredDownloadedApps[row] : nil
+			}
+		} else {
+			switch selectedTab {
+			case .signed:
+				return row < signedApps?.count ?? 0 ? signedApps?[row] : nil
+			case .downloaded:
+				return row < downloadedApps?.count ?? 0 ? downloadedApps?[row] : nil
+			}
+		}
+	}
 }
 
 extension LibraryViewController: UISearchResultsUpdating {
@@ -821,4 +877,3 @@ func presentLoader() -> UIAlertController {
 	
 	return alert
 }
-

--- a/iOS/Views/Extra/TransferPreview.swift
+++ b/iOS/Views/Extra/TransferPreview.swift
@@ -130,12 +130,11 @@ struct TransferPreview: View {
 			.padding()
 			Spacer()
 		}
-		.popover(isPresented: $showShareSheet) {
+		.popover(isPresented: $showShareSheet, arrowEdge: .bottom) {
 			if let shareURL = shareURL {
 				ActivityViewController(activityItems: [shareURL])
 			}
 		}
-
 		.animation(.spring, value: text)
 		.animation(.spring, value: icon)
 		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)

--- a/iOS/Views/Extra/TransferPreview.swift
+++ b/iOS/Views/Extra/TransferPreview.swift
@@ -130,11 +130,12 @@ struct TransferPreview: View {
 			.padding()
 			Spacer()
 		}
-		.popover(isPresented: $showShareSheet, arrowEdge: .bottom) {
+		.popover(isPresented: $showShareSheet) {
 			if let shareURL = shareURL {
 				ActivityViewController(activityItems: [shareURL])
 			}
 		}
+
 		.animation(.spring, value: text)
 		.animation(.spring, value: icon)
 		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)


### PR DESCRIPTION
## Feature Description

This PR adds the ability to delete multiple .ipa files at once in the library section by implementing a multi-select option and split Downloaded Apps and Signed Apps

### What's Added
- Edit button in the navigation bar to enter multi-select mode
- Checkboxes for selecting multiple .ipa files
- Delete button to remove all selected files
- Confirmation dialog to prevent accidental deletions
- Localization strings for the new feature

### Implementation Details
- Added properties to track editing mode state and selected items
- Modified table view cell display to show checkboxes in editing mode
- Updated selection handling to toggle item selection in edit mode
- Added confirmation dialog with count of items to be deleted
- Disabled swipe-to-delete when in editing mode

### Screenshots
<img width="559" alt="image" src="https://github.com/user-attachments/assets/7899bca5-d5b7-4b24-a0e4-bf1eddd4e3dd" />

This enhancement improves usability when managing large libraries of .ipa files by allowing users to select and delete files in bulk rather than one at a time.