### PR TITLE
Update Server+TLS.swift: 修复自定义服务器在移动网络下安装失败的问题

### DIFF
--- a/Shared/Server/Server+TLS.swift
+++ b/Shared/Server/Server+TLS.swift
@@ -13,44 +13,68 @@ import NIOTLS
 import Vapor
 import SystemConfiguration.CaptiveNetwork
 
-func getLocalIPAddress() -> String? {
-	var address: String?
-	var ifaddr: UnsafeMutablePointer<ifaddrs>?
-	
-	if getifaddrs(&ifaddr) == 0 {
-		var ptr = ifaddr
-		while ptr != nil {
-			let interface = ptr!.pointee
-			let addrFamily = interface.ifa_addr.pointee.sa_family
-			
-			if addrFamily == UInt8(AF_INET) {
-				
-				let name = String(cString: interface.ifa_name)
-				if name == "en0" || name == "pdp_ip0" {
-					
-					var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-					if getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len),
-								   &hostname, socklen_t(hostname.count),
-								   nil, socklen_t(0), NI_NUMERICHOST) == 0 {
-						address = String(cString: hostname)
-						Debug.shared.log(message: "Testing (\(name)): \(address!)")
-					}
-					
-				}
-			}
-			ptr = ptr!.pointee.ifa_next
-		}
-		freeifaddrs(ifaddr)
-	}
-	
-	return address
+// 检测设备是否使用移动数据
+func isUsingMobileData() -> Bool {
+    var address: String?
+    var ifaddr: UnsafeMutablePointer<ifaddrs>?
+
+    if getifaddrs(&ifaddr) == 0 {
+        var ptr = ifaddr
+        while ptr != nil {
+            let interface = ptr!.pointee
+            let addrFamily = interface.ifa_addr.pointee.sa_family
+
+            if addrFamily == UInt8(AF_INET) {
+                let name = String(cString: interface.ifa_name)
+                // 如果是使用移动数据的接口（pdp_ip0）
+                if name == "pdp_ip0" {
+                    address = String(cString: interface.ifa_name)
+                    break
+                }
+            }
+            ptr = ptr!.pointee.ifa_next
+        }
+        freeifaddrs(ifaddr)
+    }
+
+    return address != nil
 }
 
+// 获取本地 IP 地址
+func getLocalIPAddress() -> String? {
+    var address: String?
+    var ifaddr: UnsafeMutablePointer<ifaddrs>?
+
+    if getifaddrs(&ifaddr) == 0 {
+        var ptr = ifaddr
+        while ptr != nil {
+            let interface = ptr!.pointee
+            let addrFamily = interface.ifa_addr.pointee.sa_family
+
+            if addrFamily == UInt8(AF_INET) {
+                let name = String(cString: interface.ifa_name)
+                if name == "en0" || name == "pdp_ip0" {
+                    var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                    if getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len),
+                                   &hostname, socklen_t(hostname.count),
+                                   nil, socklen_t(0), NI_NUMERICHOST) == 0 {
+                        address = String(cString: hostname)
+                        Debug.shared.log(message: "Testing (\(name)): \(address!)")
+                    }
+                }
+            }
+            ptr = ptr!.pointee.ifa_next
+        }
+        freeifaddrs(ifaddr)
+    }
+
+    return address
+}
 
 extension Installer {
-	static let commonName = getDocumentsDirectory().appendingPathComponent("commonName.txt")
-	
-	static let sni: String = {
+    static let commonName = getDocumentsDirectory().appendingPathComponent("commonName.txt")
+    
+    static let sni: String = {
         // 判断是否用户选择了自定义服务器
         if Preferences.userSelectedServer {
             // 如果用户选择了自定义服务器，并且设备使用移动数据，设置为 127.0.0.1
@@ -64,29 +88,29 @@ extension Installer {
             return readCommonName() ?? "0.0.0.0"
         }
     }()
-	
-	static let documentsKeyURL = getDocumentsDirectory().appendingPathComponent("server.pem")
-	static let documentsCrtURL = getDocumentsDirectory().appendingPathComponent("server.crt")
+    
+    static let documentsKeyURL = getDocumentsDirectory().appendingPathComponent("server.pem")
+    static let documentsCrtURL = getDocumentsDirectory().appendingPathComponent("server.crt")
 
-	static func setupTLS() throws -> TLSConfiguration {
-		let keyURL = documentsKeyURL
-		let crtURL = documentsCrtURL
-		
-		return try TLSConfiguration.makeServerConfiguration(
-			certificateChain: NIOSSLCertificate
-				.fromPEMFile(crtURL.path)
-				.map { NIOSSLCertificateSource.certificate($0) },
+    static func setupTLS() throws -> TLSConfiguration {
+        let keyURL = documentsKeyURL
+        let crtURL = documentsCrtURL
+
+        return try TLSConfiguration.makeServerConfiguration(
+            certificateChain: NIOSSLCertificate
+                .fromPEMFile(crtURL.path)
+                .map { NIOSSLCertificateSource.certificate($0) },
             privateKey: .privateKey(try NIOSSLPrivateKey(file: keyURL.path, format: .pem)))
-	}
+    }
 }
 
 extension Installer {
-	static func readCommonName() -> String? {
-		do {
-			return try String(contentsOf: commonName, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
-		} catch {
-			Debug.shared.log(message: "Error reading commonName file: \(error.localizedDescription)")
-			return nil
-		}
-	}
+    static func readCommonName() -> String? {
+        do {
+            return try String(contentsOf: commonName, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            Debug.shared.log(message: "Error reading commonName file: \(error.localizedDescription)")
+            return nil
+        }
+    }
 }


### PR DESCRIPTION
该修复优化了在使用自定义服务器安装证书时的网络适配逻辑。当用户选择了自定义服务器并处于移动数据网络下时，SNI（Server Name Indication）将强制设置为 127.0.0.1，避免因本地 IP 获取异常导致的连接失败；在其他情况下则使用本地 IP 地址或配置文件中的常见名称，提升了兼容性与安装成功率。