### PR TITLE
修复自定义服务器在移动网络下安装失败的问题

### DIFF
--- a/Shared/Server/Server+TLS.swift
+++ b/Shared/Server/Server+TLS.swift
@@ -51,12 +51,19 @@ extension Installer {
 	static let commonName = getDocumentsDirectory().appendingPathComponent("commonName.txt")
 	
 	static let sni: String = {
-		if Preferences.userSelectedServer {
-			return getLocalIPAddress() ?? "0.0.0.0"
-		} else {
-			return readCommonName() ?? "0.0.0.0"
-		}
-	}()
+        // 判断是否用户选择了自定义服务器
+        if Preferences.userSelectedServer {
+            // 如果用户选择了自定义服务器，并且设备使用移动数据，设置为 127.0.0.1
+            if isUsingMobileData() {
+                return "127.0.0.1"
+            }
+            // 否则，获取本地 IP 地址
+            return getLocalIPAddress() ?? "0.0.0.0"
+        } else {
+            // 如果用户没有选择自定义服务器，调用 readCommonName() 读取常见名称（通常从文件或配置中读取），如果读取失败则返回 "0.0.0.0"
+            return readCommonName() ?? "0.0.0.0"
+        }
+    }()
 	
 	static let documentsKeyURL = getDocumentsDirectory().appendingPathComponent("server.pem")
 	static let documentsCrtURL = getDocumentsDirectory().appendingPathComponent("server.crt")

--- a/Shared/Server/Server+TLS.swift
+++ b/Shared/Server/Server+TLS.swift
@@ -13,44 +13,68 @@ import NIOTLS
 import Vapor
 import SystemConfiguration.CaptiveNetwork
 
-func getLocalIPAddress() -> String? {
-	var address: String?
-	var ifaddr: UnsafeMutablePointer<ifaddrs>?
-	
-	if getifaddrs(&ifaddr) == 0 {
-		var ptr = ifaddr
-		while ptr != nil {
-			let interface = ptr!.pointee
-			let addrFamily = interface.ifa_addr.pointee.sa_family
-			
-			if addrFamily == UInt8(AF_INET) {
-				
-				let name = String(cString: interface.ifa_name)
-				if name == "en0" || name == "pdp_ip0" {
-					
-					var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-					if getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len),
-								   &hostname, socklen_t(hostname.count),
-								   nil, socklen_t(0), NI_NUMERICHOST) == 0 {
-						address = String(cString: hostname)
-						Debug.shared.log(message: "Testing (\(name)): \(address!)")
-					}
-					
-				}
-			}
-			ptr = ptr!.pointee.ifa_next
-		}
-		freeifaddrs(ifaddr)
-	}
-	
-	return address
+// 检测设备是否使用移动数据
+func isUsingMobileData() -> Bool {
+    var address: String?
+    var ifaddr: UnsafeMutablePointer<ifaddrs>?
+
+    if getifaddrs(&ifaddr) == 0 {
+        var ptr = ifaddr
+        while ptr != nil {
+            let interface = ptr!.pointee
+            let addrFamily = interface.ifa_addr.pointee.sa_family
+
+            if addrFamily == UInt8(AF_INET) {
+                let name = String(cString: interface.ifa_name)
+                // 如果是使用移动数据的接口（pdp_ip0）
+                if name == "pdp_ip0" {
+                    address = String(cString: interface.ifa_name)
+                    break
+                }
+            }
+            ptr = ptr!.pointee.ifa_next
+        }
+        freeifaddrs(ifaddr)
+    }
+
+    return address != nil
 }
 
+// 获取本地 IP 地址
+func getLocalIPAddress() -> String? {
+    var address: String?
+    var ifaddr: UnsafeMutablePointer<ifaddrs>?
+
+    if getifaddrs(&ifaddr) == 0 {
+        var ptr = ifaddr
+        while ptr != nil {
+            let interface = ptr!.pointee
+            let addrFamily = interface.ifa_addr.pointee.sa_family
+
+            if addrFamily == UInt8(AF_INET) {
+                let name = String(cString: interface.ifa_name)
+                if name == "en0" || name == "pdp_ip0" {
+                    var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                    if getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len),
+                                   &hostname, socklen_t(hostname.count),
+                                   nil, socklen_t(0), NI_NUMERICHOST) == 0 {
+                        address = String(cString: hostname)
+                        Debug.shared.log(message: "Testing (\(name)): \(address!)")
+                    }
+                }
+            }
+            ptr = ptr!.pointee.ifa_next
+        }
+        freeifaddrs(ifaddr)
+    }
+
+    return address
+}
 
 extension Installer {
-	static let commonName = getDocumentsDirectory().appendingPathComponent("commonName.txt")
-	
-	static let sni: String = {
+    static let commonName = getDocumentsDirectory().appendingPathComponent("commonName.txt")
+    
+    static let sni: String = {
         // 判断是否用户选择了自定义服务器
         if Preferences.userSelectedServer {
             // 如果用户选择了自定义服务器，并且设备使用移动数据，设置为 127.0.0.1
@@ -64,29 +88,29 @@ extension Installer {
             return readCommonName() ?? "0.0.0.0"
         }
     }()
-	
-	static let documentsKeyURL = getDocumentsDirectory().appendingPathComponent("server.pem")
-	static let documentsCrtURL = getDocumentsDirectory().appendingPathComponent("server.crt")
+    
+    static let documentsKeyURL = getDocumentsDirectory().appendingPathComponent("server.pem")
+    static let documentsCrtURL = getDocumentsDirectory().appendingPathComponent("server.crt")
 
-	static func setupTLS() throws -> TLSConfiguration {
-		let keyURL = documentsKeyURL
-		let crtURL = documentsCrtURL
-		
-		return try TLSConfiguration.makeServerConfiguration(
-			certificateChain: NIOSSLCertificate
-				.fromPEMFile(crtURL.path)
-				.map { NIOSSLCertificateSource.certificate($0) },
+    static func setupTLS() throws -> TLSConfiguration {
+        let keyURL = documentsKeyURL
+        let crtURL = documentsCrtURL
+
+        return try TLSConfiguration.makeServerConfiguration(
+            certificateChain: NIOSSLCertificate
+                .fromPEMFile(crtURL.path)
+                .map { NIOSSLCertificateSource.certificate($0) },
             privateKey: .privateKey(try NIOSSLPrivateKey(file: keyURL.path, format: .pem)))
-	}
+    }
 }
 
 extension Installer {
-	static func readCommonName() -> String? {
-		do {
-			return try String(contentsOf: commonName, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
-		} catch {
-			Debug.shared.log(message: "Error reading commonName file: \(error.localizedDescription)")
-			return nil
-		}
-	}
+    static func readCommonName() -> String? {
+        do {
+            return try String(contentsOf: commonName, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            Debug.shared.log(message: "Error reading commonName file: \(error.localizedDescription)")
+            return nil
+        }
+    }
 }

--- a/Shared/Server/Server+TLS.swift
+++ b/Shared/Server/Server+TLS.swift
@@ -13,104 +13,78 @@ import NIOTLS
 import Vapor
 import SystemConfiguration.CaptiveNetwork
 
-// 检测设备是否使用移动数据
-func isUsingMobileData() -> Bool {
-    var address: String?
-    var ifaddr: UnsafeMutablePointer<ifaddrs>?
-
-    if getifaddrs(&ifaddr) == 0 {
-        var ptr = ifaddr
-        while ptr != nil {
-            let interface = ptr!.pointee
-            let addrFamily = interface.ifa_addr.pointee.sa_family
-
-            if addrFamily == UInt8(AF_INET) {
-                let name = String(cString: interface.ifa_name)
-                // 如果是使用移动数据的接口（pdp_ip0）
-                if name == "pdp_ip0" {
-                    address = String(cString: interface.ifa_name)
-                    break
-                }
-            }
-            ptr = ptr!.pointee.ifa_next
-        }
-        freeifaddrs(ifaddr)
-    }
-
-    return address != nil
-}
-
-// 获取本地 IP 地址
 func getLocalIPAddress() -> String? {
-    var address: String?
-    var ifaddr: UnsafeMutablePointer<ifaddrs>?
-
-    if getifaddrs(&ifaddr) == 0 {
-        var ptr = ifaddr
-        while ptr != nil {
-            let interface = ptr!.pointee
-            let addrFamily = interface.ifa_addr.pointee.sa_family
-
-            if addrFamily == UInt8(AF_INET) {
-                let name = String(cString: interface.ifa_name)
-                if name == "en0" || name == "pdp_ip0" {
-                    var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-                    if getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len),
-                                   &hostname, socklen_t(hostname.count),
-                                   nil, socklen_t(0), NI_NUMERICHOST) == 0 {
-                        address = String(cString: hostname)
-                        Debug.shared.log(message: "Testing (\(name)): \(address!)")
-                    }
-                }
-            }
-            ptr = ptr!.pointee.ifa_next
-        }
-        freeifaddrs(ifaddr)
-    }
-
-    return address
+	var address: String?
+	var ifaddr: UnsafeMutablePointer<ifaddrs>?
+	
+	if getifaddrs(&ifaddr) == 0 {
+		var ptr = ifaddr
+		while ptr != nil {
+			let interface = ptr!.pointee
+			let addrFamily = interface.ifa_addr.pointee.sa_family
+			
+			if addrFamily == UInt8(AF_INET) {
+				
+				let name = String(cString: interface.ifa_name)
+				if name == "en0" || name == "pdp_ip0" {
+					
+					var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+					if getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len),
+								   &hostname, socklen_t(hostname.count),
+								   nil, socklen_t(0), NI_NUMERICHOST) == 0 {
+						switch name {
+                        case "pdp_ip0":
+                            address = "127.0.0.1"
+                        default:
+                            address = String(cString: hostname)
+                        }
+						Debug.shared.log(message: "Testing (\(name)): \(address!)")
+					}
+					
+				}
+			}
+			ptr = ptr!.pointee.ifa_next
+		}
+		freeifaddrs(ifaddr)
+	}
+	
+	return address
 }
 
+
 extension Installer {
-    static let commonName = getDocumentsDirectory().appendingPathComponent("commonName.txt")
-    
-    static let sni: String = {
-        // 判断是否用户选择了自定义服务器
-        if Preferences.userSelectedServer {
-            // 如果用户选择了自定义服务器，并且设备使用移动数据，设置为 127.0.0.1
-            if isUsingMobileData() {
-                return "127.0.0.1"
-            }
-            // 否则，获取本地 IP 地址
-            return getLocalIPAddress() ?? "0.0.0.0"
-        } else {
-            // 如果用户没有选择自定义服务器，调用 readCommonName() 读取常见名称（通常从文件或配置中读取），如果读取失败则返回 "0.0.0.0"
-            return readCommonName() ?? "0.0.0.0"
-        }
-    }()
-    
-    static let documentsKeyURL = getDocumentsDirectory().appendingPathComponent("server.pem")
-    static let documentsCrtURL = getDocumentsDirectory().appendingPathComponent("server.crt")
+	static let commonName = getDocumentsDirectory().appendingPathComponent("commonName.txt")
+	
+	static let sni: String = {
+		if Preferences.userSelectedServer {
+			return getLocalIPAddress() ?? "0.0.0.0"
+		} else {
+			return readCommonName() ?? "0.0.0.0"
+		}
+	}()
+	
+	static let documentsKeyURL = getDocumentsDirectory().appendingPathComponent("server.pem")
+	static let documentsCrtURL = getDocumentsDirectory().appendingPathComponent("server.crt")
 
-    static func setupTLS() throws -> TLSConfiguration {
-        let keyURL = documentsKeyURL
-        let crtURL = documentsCrtURL
-
-        return try TLSConfiguration.makeServerConfiguration(
-            certificateChain: NIOSSLCertificate
-                .fromPEMFile(crtURL.path)
-                .map { NIOSSLCertificateSource.certificate($0) },
+	static func setupTLS() throws -> TLSConfiguration {
+		let keyURL = documentsKeyURL
+		let crtURL = documentsCrtURL
+		
+		return try TLSConfiguration.makeServerConfiguration(
+			certificateChain: NIOSSLCertificate
+				.fromPEMFile(crtURL.path)
+				.map { NIOSSLCertificateSource.certificate($0) },
             privateKey: .privateKey(try NIOSSLPrivateKey(file: keyURL.path, format: .pem)))
-    }
+	}
 }
 
 extension Installer {
-    static func readCommonName() -> String? {
-        do {
-            return try String(contentsOf: commonName, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
-        } catch {
-            Debug.shared.log(message: "Error reading commonName file: \(error.localizedDescription)")
-            return nil
-        }
-    }
+	static func readCommonName() -> String? {
+		do {
+			return try String(contentsOf: commonName, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+		} catch {
+			Debug.shared.log(message: "Error reading commonName file: \(error.localizedDescription)")
+			return nil
+		}
+	}
 }


### PR DESCRIPTION
根据当前设备的网络接口判断，若当前接口为 pdp_ip0（即移动数据网络），强制使用 SNI 为 127.0.0.1，提升了兼容性。从而修复了自定义服务器在移动网络下安装失败的问题。