### PR TITLE
fix: URL encoding for non-ASCII characters in online installation

### DIFF
--- a/Shared/Server/Server.swift
+++ b/Shared/Server/Server.swift
@@ -82,8 +82,10 @@ class Installer: Identifiable, ObservableObject {
 		}
 		
 		app.get("i") { req -> Response in
-
-			let testurl = "itms-services://?action=download-manifest&url=" + ("\(Preferences.onlinePath ?? Preferences.defaultInstallPath)/genPlist?bundleid=\(metadata.id)&name=\(metadata.name)&version=\(metadata.name)&fetchurl=\(self.payloadEndpoint.absoluteString)").addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
+			let baseUrl = "\(Preferences.onlinePath ?? Preferences.defaultInstallPath)/genPlist?bundleid=\(metadata.id)&name=\(metadata.name)&version=\(metadata.name)&fetchurl=\(self.payloadEndpoint.absoluteString)"
+			let encodedBaseUrl = baseUrl.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+			let finalEncodedUrl = encodedBaseUrl.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
+			let testurl = "itms-services://?action=download-manifest&url=" + finalEncodedUrl
 
 			var html = ""
 			


### PR DESCRIPTION
### 🛠 Problem

Online installation fails when app names include non-ASCII characters (e.g., **Chinese**, **Japanese**, **Korean**) due to improper URL encoding.

### ✅ Solution

Apply a two-step encoding process to ensure URL safety:

1. **UTF-8 encode** non-ASCII characters
2. **Percent-encode** the result to escape special characters

### 🧪 Testing

Verified the fix works with the following input types:

- ✅ ASCII (e.g., English letters, numbers)
- ✅ Chinese (**中文**)
- ✅ Japanese (**日本語**)
- ✅ Korean (**한국어**)