### PR TITLE
fix: repo bundle identifier mismatch with ipa

### DIFF
--- a/app-repo.json
+++ b/app-repo.json
@@ -6,7 +6,7 @@
   "apps": [
     {
       "name": "Feather",
-      "bundleIdentifier": "kh.crysalis.feather",
+      "bundleIdentifier": "thewonderofyou.Feather",
       "developerName": "Samara",
       "iconURL": "https://github.com/khcrysalis/Feather/blob/v1/iOS/Resources/Icons/Main/Mac%403x.png?raw=true",
       "localizedDescription": "Feather is a free on-device iOS application manager/installer built with UIKit for quality.",
@@ -34,7 +34,7 @@
     },
     {
       "name": "Feather (idevice)",
-      "bundleIdentifier": "kh.crysalis.feather-idevice",
+      "bundleIdentifier": "thewonderofyou.Feather-idevice",
       "developerName": "Samara",
       "iconURL": "https://github.com/khcrysalis/Feather/blob/v1/iOS/Resources/Icons/Main/Mac%403x.png?raw=true",
       "localizedDescription": "Feather is a free on-device iOS application manager/installer built with UIKit for quality.",


### PR DESCRIPTION
### Description

This PR updates the `bundleIdentifier` values in `app-repo.json` for the "Feather" and "Feather (idevice)" applications. The previously listed bundle identifiers did not match the actual identifiers embedded within the compiled IPA files.

This mismatch could lead to issues with app installation, updates, or proper recognition by app management tools (e.g., AltStore, SideStore) that consume this repository metadata.

![A7824F34-C5DF-42AB-8008-5ED8AE34FDA6_1_201_a](https://github.com/user-attachments/assets/d9da4c65-0137-4172-9f01-eb9686438e8f)

### Additional Note
In `app-repo.json`, you might also want to update the repo identifier on line 3.