### PR TITLE
Remove _CodeSignature folder to SigningHandler

### DIFF
--- a/Feather/Utilities/Handlers/SigningHandler.swift
+++ b/Feather/Utilities/Handlers/SigningHandler.swift
@@ -49,6 +49,7 @@ final class SigningHandler: NSObject {
 		print(movedAppURL)
 		
 		try _fileManager.copyItem(at: appUrl, to: movedAppURL)
+        removeCodeSignatureIfExists(at: movedAppURL)
 		_movedAppPath = movedAppURL
 		print("[\(_uuid)] Moved Payload to: \(movedAppURL.path)")
 	}
@@ -147,6 +148,17 @@ final class SigningHandler: NSObject {
 	func clean() async throws {
 		try _fileManager.removeFileIfNeeded(at: _uniqueWorkDir)
 	}
+    private func removeCodeSignatureIfExists(at appFolder: URL) {
+        let codeSignatureURL = appFolder.appendingPathComponent("_CodeSignature")
+        if _fileManager.fileExists(atPath: codeSignatureURL.path) {
+            do {
+                try _fileManager.removeItem(at: codeSignatureURL)
+                print("[SigningHandler] Removed _CodeSignature from \(appFolder.lastPathComponent)")
+            } catch {
+                print("[SigningHandler] Failed to remove _CodeSignature: \(error)")
+            }
+        }
+    }
 }
 
 extension SigningHandler {


### PR DESCRIPTION
Relocated the logic for removing the `_CodeSignature` directory from AppFileHandler to SigningHandler as per project architecture guidelines. This ensures IPA modifications are handled exclusively within SigningHandler, avoiding side effects during app data handling.

- Added `removeCodeSignatureIfExists(at:)` function to SigningHandler.
- Called the cleanup function in `copy()` after copying the app bundle.