### PR TITLE
Fix autocapitalization

### DIFF
--- a/Feather/Views/Library/LibraryView.swift
+++ b/Feather/Views/Library/LibraryView.swift
@@ -144,6 +144,7 @@ struct LibraryView: View {
 			}
 			.alert(.localized("Import from URL"), isPresented: $_isDownloadingPresenting) {
 				TextField(.localized("URL"), text: $_alertDownloadString)
+					.textInputAutocapitalization(.never)
 				Button(.localized("Cancel"), role: .cancel) {
 					_alertDownloadString = ""
 				}

--- a/Feather/Views/Sources/SourcesAddView.swift
+++ b/Feather/Views/Sources/SourcesAddView.swift
@@ -29,6 +29,7 @@ struct SourcesAddView: View {
 				Section {
 					TextField(.localized("Source Repo URL"), text: $_sourceURL)
 						.keyboardType(.URL)
+						.textInputAutocapitalization(.never)
 				} footer: {
 					Text(.localized("Enter a URL to start validation."))
 				}


### PR DESCRIPTION
Turns off autocapitalization for URL fields in sources and library (gets rather annoying for iPad keyboards especially).
My first time contributing in Swift, please tell me if anything looks off!