### PR TITLE
Feather(Views): Added some context symbol to navigation buttons, also remove revoke check for simulators

### DIFF
--- a/Feather/Backend/Storage/Storage+Certificate.swift
+++ b/Feather/Backend/Storage/Storage+Certificate.swift
@@ -28,8 +28,9 @@ extension Storage {
 		new.ppQCheck = ppq
 		new.expiration = expiration
 		new.nickname = nickname
+        #if !targetEnvironment(simulator)
 		Storage.shared.revokagedCertificate(for: new)
-		
+        #endif
 		saveContext()
 		generator.impactOccurred()
 		completion(nil)

--- a/Feather/Views/Settings/Certificates/CertificatesView.swift
+++ b/Feather/Views/Settings/Certificates/CertificatesView.swift
@@ -124,11 +124,11 @@ extension CertificatesView {
 		Button(.localized("Get Info"), systemImage: "info.circle") {
 			_isSelectedInfoPresenting = cert
 		}
-		
 		Divider()
-		
+        #if !targetEnvironment(simulator)
 		Button(.localized("Check Revokage"), systemImage: "person.text.rectangle") {
 			Storage.shared.revokagedCertificate(for: cert)
 		}
+        #endif
 	}
 }

--- a/Feather/Views/Settings/SettingsView.swift
+++ b/Feather/Views/Settings/SettingsView.swift
@@ -26,17 +26,29 @@ struct SettingsView: View {
 				_feedback()
 				
 				Section {
-					NavigationLink(.localized("Appearance"), destination: AppearanceView())
+					NavigationLink(destination: AppearanceView()) {
+						Label(.localized("Appearance"), systemImage: "paintbrush")
+					}
 					if UIDevice.current.doesHaveAppIdCapabilities {
-						NavigationLink(.localized("App Icon"), destination: AppIconView(currentIcon: $_currentIcon))
+						NavigationLink(destination: AppIconView(currentIcon: $_currentIcon)) {
+							Label(.localized("App Icon"), systemImage: "app.badge")
+						}
 					}
 				}
 				
 				NBSection(.localized("Features")) {
-					NavigationLink(.localized("Certificates"), destination: CertificatesView())
-					NavigationLink(.localized("Signing Options"), destination: ConfigurationView())
-					NavigationLink(.localized("Archive & Compression"), destination: ArchiveView())
-					NavigationLink(.localized("Installation"), destination: InstallationView())
+					NavigationLink(destination: CertificatesView()) {
+						Label(.localized("Certificates"), systemImage: "checkmark.seal")
+					}
+					NavigationLink(destination: ConfigurationView()) {
+						Label(.localized("Signing Options"), systemImage: "signature")
+					}
+					NavigationLink(destination: ArchiveView()) {
+						Label(.localized("Archive & Compression"), systemImage: "archivebox")
+					}
+					NavigationLink(destination: InstallationView()) {
+						Label(.localized("Installation"), systemImage: "arrow.down.circle")
+					}
 				} footer: {
 					Text(.localized("Configure the apps way of installing, its zip compression levels, and custom modifications to apps."))
 				}
@@ -44,7 +56,9 @@ struct SettingsView: View {
 				_directories()
 				
 				Section {
-					NavigationLink(.localized("Reset"), destination: ResetView())
+					NavigationLink(destination: ResetView()) {
+						Label(.localized("Reset"), systemImage: "trash")
+					}
 				} footer: {
 					Text(.localized("Reset the applications sources, certificates, apps, and general contents."))
 				}

--- a/Feather/Views/Settings/Signing Options/ConfigurationView.swift
+++ b/Feather/Views/Settings/Signing Options/ConfigurationView.swift
@@ -17,16 +17,20 @@ struct ConfigurationView: View {
 	// MARK: Body
     var body: some View {
 		NBList(.localized("Signing Options")) {
-			NavigationLink(.localized("Display Names"), destination: ConfigurationDictView(
+			NavigationLink(destination: ConfigurationDictView(
 				title: .localized("Display Names"),
 					dataDict: $_optionsManager.options.displayNames
 				)
-			)
-			NavigationLink(.localized("Identifers"), destination: ConfigurationDictView(
+			) {
+				Label(.localized("Display Names"), systemImage: "character.cursor.ibeam")
+			}
+			NavigationLink(destination: ConfigurationDictView(
 					title: .localized("Identifers"),
 					dataDict: $_optionsManager.options.identifiers
 				)
-			)
+			) {
+				Label(.localized("Identifers"), systemImage: "person.text.rectangle")
+			}
 			
 			SigningOptionsView(options: $_optionsManager.options)
 		}


### PR DESCRIPTION
Symbol one is self explanatory, removed revoke check for simulators because this would crash the app, waiting for future fixes if necessary 