### PR TITLE
Add bulk deletions for library tab

### DIFF
--- a/Feather/Views/Library/LibraryCellView.swift
+++ b/Feather/Views/Library/LibraryCellView.swift
@@ -12,6 +12,7 @@ import NimbleViews
 // MARK: - View
 struct LibraryCellView: View {
 	@Environment(\.horizontalSizeClass) private var horizontalSizeClass
+	@Environment(\.editMode) private var editMode
 
 	var certInfo: Date.ExpirationInfo? {
 		Storage.shared.getCertificate(from: app)?.expiration?.expirationInfo()
@@ -25,12 +26,40 @@ struct LibraryCellView: View {
 	@Binding var selectedInfoAppPresenting: AnyApp?
 	@Binding var selectedSigningAppPresenting: AnyApp?
 	@Binding var selectedInstallAppPresenting: AnyApp?
+	@Binding var selectedAppUUIDs: Set<String>
+	
+	// MARK: Selections
+	private var _isSelected: Bool {
+		guard let uuid = app.uuid else { return false }
+		return selectedAppUUIDs.contains(uuid)
+	}
+	
+	private func _toggleSelection() {
+		guard let uuid = app.uuid else { return }
+		if selectedAppUUIDs.contains(uuid) {
+			selectedAppUUIDs.remove(uuid)
+		} else {
+			selectedAppUUIDs.insert(uuid)
+		}
+	}
 	
 	// MARK: Body
 	var body: some View {
 		let isRegular = horizontalSizeClass != .compact
+		let isEditing = editMode?.wrappedValue == .active
 		
 		HStack(spacing: 18) {
+			if isEditing {
+				Button {
+					_toggleSelection()
+				} label: {
+					Image(systemName: _isSelected ? "checkmark.circle.fill" : "circle")
+						.foregroundColor(_isSelected ? .accentColor : .secondary)
+						.font(.title2)
+				}
+				.buttonStyle(.borderless)
+			}
+			
 			FRAppIconView(app: app, size: 57)
 			
 			NBTitleWithSubtitleView(
@@ -39,24 +68,36 @@ struct LibraryCellView: View {
 				linelimit: 0
 			)
 			
-			_buttonActions(for: app)
+			if !isEditing {
+				_buttonActions(for: app)
+			}
 		}
 		.padding(isRegular ? 12 : 0)
 		.background(
 			isRegular
 			? RoundedRectangle(cornerRadius: 18, style: .continuous)
-				.fill(Color(.quaternarySystemFill))
+				.fill(_isSelected && isEditing ? Color.accentColor.opacity(0.1) : Color(.quaternarySystemFill))
 			: nil
 		)
+		.contentShape(Rectangle())
+		.onTapGesture {
+			if isEditing {
+				_toggleSelection()
+			}
+		}
 		.swipeActions {
-			_actions(for: app)
+			if !isEditing {
+				_actions(for: app)
+			}
 		}
 		.contextMenu {
-			_contextActions(for: app)
-			Divider()
-			_contextActionsExtra(for: app)
-			Divider()
-			_actions(for: app)
+			if !isEditing {
+				_contextActions(for: app)
+				Divider()
+				_contextActionsExtra(for: app)
+				Divider()
+				_actions(for: app)
+			}
 		}
 	}
 	

--- a/Feather/Views/Library/LibraryView.swift
+++ b/Feather/Views/Library/LibraryView.swift
@@ -268,7 +268,3 @@ extension LibraryView {
 		}
 	}
 }
-
-#Preview {
-    LibraryView()
-}

--- a/Feather/Views/Library/LibraryView.swift
+++ b/Feather/Views/Library/LibraryView.swift
@@ -140,7 +140,6 @@ struct LibraryView: View {
 			.toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     EditButton()
-						.environment(\.editMode, $_editMode)
                 }
 				
 				if _editMode.isEditing {

--- a/Feather/Views/Library/LibraryView.swift
+++ b/Feather/Views/Library/LibraryView.swift
@@ -143,7 +143,7 @@ struct LibraryView: View {
                 }
 				
 				if _editMode.isEditing {
-					NBToolbarButton(.localized("Delete"), systemImage: "trash") {
+                    NBToolbarButton(.localized("Delete"), systemImage: "trash", isDisabled: _selectedAppUUIDs.isEmpty) {
 						_bulkDeleteSelectedApps()
 					}
 				} else {

--- a/Feather/Views/Library/LibraryView.swift
+++ b/Feather/Views/Library/LibraryView.swift
@@ -20,8 +20,13 @@ struct LibraryView: View {
 	@State private var _isDownloadingPresenting = false
 	@State private var _alertDownloadString: String = "" // for _isDownloadingPresenting
 	
+	// MARK: Selection State
+	@State private var _selectedAppUUIDs: Set<String> = []
+	@State private var _editMode: EditMode = .inactive
+	
 	@State private var _searchText = ""
 	@State private var _selectedScope: Scope = .all
+
 	
 	@Namespace private var _namespace
 	
@@ -75,7 +80,8 @@ struct LibraryView: View {
 									app: app,
 									selectedInfoAppPresenting: $_selectedInfoAppPresenting,
 									selectedSigningAppPresenting: $_selectedSigningAppPresenting,
-									selectedInstallAppPresenting: $_selectedInstallAppPresenting
+									selectedInstallAppPresenting: $_selectedInstallAppPresenting,
+									selectedAppUUIDs: $_selectedAppUUIDs // send to cell view
 								)
 								.compatMatchedTransitionSource(id: app.uuid ?? "", ns: _namespace)
 							}
@@ -95,7 +101,8 @@ struct LibraryView: View {
 									app: app,
 									selectedInfoAppPresenting: $_selectedInfoAppPresenting,
 									selectedSigningAppPresenting: $_selectedSigningAppPresenting,
-									selectedInstallAppPresenting: $_selectedInstallAppPresenting
+									selectedInstallAppPresenting: $_selectedInstallAppPresenting,
+									selectedAppUUIDs: $_selectedAppUUIDs
 								)
 								.compatMatchedTransitionSource(id: app.uuid ?? "", ns: _namespace)
 							}
@@ -131,14 +138,26 @@ struct LibraryView: View {
 				}
 			}
 			.toolbar {
-				NBToolbarMenu(
-					systemImage: "plus",
-					style: .icon,
-					placement: .topBarTrailing
-				) {
-					_importActions()
+                ToolbarItem(placement: .topBarLeading) {
+                    EditButton()
+						.environment(\.editMode, $_editMode)
+                }
+				
+				if _editMode.isEditing {
+					NBToolbarButton(.localized("Delete"), systemImage: "trash") {
+						_bulkDeleteSelectedApps()
+					}
+				} else {
+					NBToolbarMenu(
+						systemImage: "plus",
+						style: .icon,
+						placement: .topBarTrailing
+					) {
+						_importActions()
+					}
 				}
 			}
+			.environment(\.editMode, $_editMode)
 			.sheet(item: $_selectedInfoAppPresenting) { app in
 				LibraryInfoView(app: app.base)
 			}
@@ -180,6 +199,11 @@ struct LibraryView: View {
 					}
 				}
 			}
+			.onChange(of: _editMode) { mode in
+				if mode == .inactive {
+					_selectedAppUUIDs.removeAll()
+				}
+			}
         }
     }
 }
@@ -194,6 +218,38 @@ extension LibraryView {
 		Button(.localized("Import from URL"), systemImage: "globe") {
 			_isDownloadingPresenting = true
 		}
+	}
+}
+
+// MARK: - Extension: Bulk Delete
+extension LibraryView {
+	private func _bulkDeleteSelectedApps() {
+		let selectedApps = _getAllApps().filter { app in
+			guard let uuid = app.uuid else { return false }
+			return _selectedAppUUIDs.contains(uuid)
+		}
+		
+		for app in selectedApps {
+			Storage.shared.deleteApp(for: app)
+		}
+		
+		_selectedAppUUIDs.removeAll()
+		
+		// _editMode = .inactive
+	}
+	
+	private func _getAllApps() -> [AppInfoPresentable] {
+		var allApps: [AppInfoPresentable] = []
+		
+		if _selectedScope == .all || _selectedScope == .signed {
+			allApps.append(contentsOf: _filteredSignedApps)
+		}
+		
+		if _selectedScope == .all || _selectedScope == .imported {
+			allApps.append(contentsOf: _filteredImportedApps)
+		}
+		
+		return allApps
 	}
 }
 
@@ -212,4 +268,8 @@ extension LibraryView {
 			}
 		}
 	}
+}
+
+#Preview {
+    LibraryView()
 }


### PR DESCRIPTION
Added this for those with a lot of apps to delete but don’t want to swipe every cell to delete it, added as custom selections for the library tab since NBListAdaptable does not support selections