### PR TITLE
Bump xcode version used in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
         with:
           submodules: 'true'
       
-      - name: Use Xcode 16.2
+      - name: Use Xcode 16.4
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Compile Feather
         run: | 


### PR DESCRIPTION
Bump used Xcode version to 16.4
On lowest than 16.4 build on workflow will not success.

Ref: https://github.com/actions/runner-images/issues/12751