### PR TITLE
Feather(Views): Fix theme section clipping on iOS 26

### DIFF
--- a/Feather/Views/Settings/Appearance/AppearanceTintColorView.swift
+++ b/Feather/Views/Settings/Appearance/AppearanceTintColorView.swift
@@ -23,13 +23,17 @@ struct AppearanceTintColorView: View {
 		("Very Peculiar", 	"#5394F7"),
 		("Emily",			"#e18aab")
 	]
-	
+
+	@AppStorage("com.apple.SwiftUI.IgnoreSolariumLinkedOnCheck")
+	private var _ignoreSolariumLinkedOnCheck: Bool = false
+
 	// MARK: Body
 	var body: some View {
 		ScrollView(.horizontal, showsIndicators: false) {
 			LazyHGrid(rows: [GridItem(.fixed(100))], spacing: 12) {
 				ForEach(tintOptions, id: \.hex) { option in
 					let color = Color(hex: option.hex)
+					let cornerRadius = _ignoreSolariumLinkedOnCheck ? 28.0 : 10.5
 					VStack(spacing: 8) {
 						Circle()
 							.fill(color)
@@ -38,16 +42,16 @@ struct AppearanceTintColorView: View {
 								Circle()
 									.strokeBorder(Color.black.opacity(0.3), lineWidth: 2)
 							)
-						
+
 						Text(option.name)
 							.font(.subheadline)
 							.foregroundColor(.secondary)
 					}
 					.frame(width: 120, height: 100)
 					.background(Color(uiColor: .secondarySystemGroupedBackground))
-					.clipShape(RoundedRectangle(cornerRadius: 10.5, style: .continuous))
+					.clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
 					.overlay(
-						RoundedRectangle(cornerRadius: 10.5, style: .continuous)
+						RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 							.strokeBorder(selectedColorHex == option.hex ? color : .clear, lineWidth: 2)
 					)
 					.onTapGesture {


### PR DESCRIPTION
| iOS Version | Before | After |
|--------|--------|--------|
| iOS 18 | <video src=https://github.com/user-attachments/assets/0ffabdb9-a682-4626-b5ce-33a8b06dad76> | <video src=https://github.com/user-attachments/assets/0ffabdb9-a682-4626-b5ce-33a8b06dad76> |
| iOS 26 | <video src=https://github.com/user-attachments/assets/86d4437c-e770-44b8-8f2f-c88898c54335> | <video src=https://github.com/user-attachments/assets/c0286d94-aad9-46fa-9877-799fa73764cb> | 