### PR TITLE
Fix text cutoff in donation list

### DIFF
--- a/Feather/Views/Settings/SettingsDonationCellView.swift
+++ b/Feather/Views/Settings/SettingsDonationCellView.swift
@@ -74,7 +74,7 @@ struct SettingsDonationCellView: View {
 			NBTitleWithSubtitleView(
 				title: title,
 				subtitle: desc
-			)
+			).fixedSize(horizontal: false, vertical: true)
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes the text cutoff in the donation benefit list.
Before: 
<img width="603" height="1311" alt="IMG_4542" src="https://github.com/user-attachments/assets/17e7c981-7221-409e-b0ce-616931395228" />
After:
<img width="603" height="1311" alt="IMG_4543" src="https://github.com/user-attachments/assets/12d4486b-ecfe-400c-a717-c718544e99d6" />
