### PR TITLE
Fix typo in signing options settings page

### DIFF
--- a/Feather/Resources/Localizable.xcstrings
+++ b/Feather/Resources/Localizable.xcstrings
@@ -5975,7 +5975,7 @@
         }
       }
     },
-    "Identifers" : {
+    "Identifiers" : {
       "extractionState" : "manual",
       "localizations" : {
         "cs" : {
@@ -5993,7 +5993,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Identifers"
+            "value" : "Identifiers"
           }
         },
         "id" : {

--- a/Feather/Views/Settings/Signing Options/ConfigurationView.swift
+++ b/Feather/Views/Settings/Signing Options/ConfigurationView.swift
@@ -26,11 +26,11 @@ struct ConfigurationView: View {
                     Label(.localized("Display Names"), systemImage: "character.cursor.ibeam")
                 }
                 NavigationLink(destination: ConfigurationDictView(
-                        title: .localized("Identifers"),
+                        title: .localized("Identifiers"),
                         dataDict: $_optionsManager.options.identifiers
                     )
                 ) {
-                    Label(.localized("Identifers"), systemImage: "person.text.rectangle")
+                    Label(.localized("Identifiers"), systemImage: "person.text.rectangle")
                 }
             }footer: {
                 Text(.localized("This allows you to set rules for automatically replacing the Bundle ID/Display Name when signing an app."))


### PR DESCRIPTION
Fixes "Identifers" typo with the en localized string. Changed to "Identifiers".

I grepped "Identifers" and renamed all references.
I didn't test it, so hopefully it's all fine :3