### PR TITLE
Lang(de): Improve and add missing translations

### DIFF
--- a/Feather/Resources/Localizable.xcstrings
+++ b/Feather/Resources/Localizable.xcstrings
@@ -516,7 +516,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "💜 Dies wäre alles nicht möglich ohne meine Sponsoren!"
+            "value" : "💜 Ohne meine Sponsoren wäre das alles nicht möglich!"
           }
         },
         "en" : {
@@ -989,7 +989,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alle Dateien der App befinden sich im Dokumente-Verzeichnis, hier sind einige Schnellzugriffe darauf."
+            "value" : "Alle App-Dateien liegen im Dokumente-Verzeichnis. Hier sind einige Schnellzugriffe."
           }
         },
         "en" : {


### PR DESCRIPTION
I missed some texts because I just used ctrl + f to search for "de". Everything should be translated now I checked again just to be sure