### PR TITLE
fix: show success alert after updating certificates

### DIFF
--- a/Feather/Resources/Localizable.xcstrings
+++ b/Feather/Resources/Localizable.xcstrings
@@ -2136,6 +2136,17 @@
         }
       }
     },
+    "Certificates updated successfully." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certificates updated successfully."
+          }
+        }
+      }
+    },
     "Change" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Feather/Views/Settings/Installation/Server & SSL/ServerView.swift
+++ b/Feather/Views/Settings/Installation/Server & SSL/ServerView.swift
@@ -71,7 +71,14 @@ struct ServerView: View {
 			Section {
 				Button(.localized("Update SSL Certificates"), systemImage: "arrow.down.doc") {
 					FR.downloadSSLCertificates(from: _serverPackUrl) { success in
-						if !success {
+						if success {
+							DispatchQueue.main.async {
+								UIAlertController.showAlertWithOk(
+									title: .localized("SSL Certificates"),
+									message: .localized("Certificates updated successfully.")
+								)
+							}
+						} else {
 							DispatchQueue.main.async {
 								UIAlertController.showAlertWithOk(
 									title: .localized("SSL Certificates"),


### PR DESCRIPTION
Many new users to Feather, especially on iPad where haptic feedback is unavailable, get confused when updating SSL certificates because there is no confirmation that it was successful.

<img width="301.5" height="655.5" alt="Simulator Screenshot" src="https://github.com/user-attachments/assets/f099f56d-2308-4776-8300-38bfaa8a750f" />
