### PR TITLE
Update recommended sources list

### DIFF
--- a/Feather/Views/Sources/SourcesAddView.swift
+++ b/Feather/Views/Sources/SourcesAddView.swift
@@ -38,7 +38,7 @@ struct SourcesAddView: View {
 	let recommendedSources: [URL] = [
 		"https://raw.githubusercontent.com/khcrysalis/Feather/refs/heads/main/app-repo.json",
 		"https://raw.githubusercontent.com/Aidoku/Aidoku/altstore/apps.json",
-		"https://flyinghead.github.io/flycast-builds/altstore.json",
+		"https://github.com/chachillie/Flycast-iOS/raw/main/flycast-ios.json",
 		"https://xitrix.github.io/iTorrent/AltStore.json",
 		"https://altstore.oatmealdome.me/",
 		"https://raw.githubusercontent.com/LiveContainer/LiveContainer/refs/heads/main/apps.json",
@@ -47,7 +47,10 @@ struct SourcesAddView: View {
 		"https://provenance-emu.com/apps.json",
 		"https://community-apps.sidestore.io/sidecommunity.json",
 		"https://alt.getutm.app",
-		"https://raw.githubusercontent.com/paigely/Navic/refs/heads/master/app-repo.json"
+		"https://raw.githubusercontent.com/paigely/Navic/refs/heads/master/app-repo.json",
+		"https://stikdebug.xyz/index.json",
+		"https://apps.manicemu.site/altstore",
+		"https://alt.crystall1ne.dev"
 	].map { URL(string: $0)! }
 	
 	@State private var _isImporting = false


### PR DESCRIPTION
Replace Flyinghead source with live, iOS 26 patched version, add StikDebug, Manic EMU, and Angel Aura Amethyst.