### PR TITLE
ci: improve submodule and LFS handling in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          submodules: 'true'
+          submodules: 'recursive'
+          persist-credentials: false
+
+      - name: Pull Git LFS assets for IDeviceKitten
+        run: |
+          git config --global --unset-all http.https://github.com/.extraheader || true
+          git -C IDeviceKitten config --unset-all http.https://github.com/.extraheader || true
+          git -C IDeviceKitten lfs pull
       
       - name: Use Xcode 26.2
         run: |

--- a/.github/workflows/update_repo.yml
+++ b/.github/workflows/update_repo.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Update app-repo.json
         run: |
           ./update-repo.sh
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           default_author: github_actions
           message: "chore: update repo"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "Zsign"]
 	path = Zsign
-	url = https://github.com/khcrysalis/Zsign-Package
+	url = https://github.com/CLARATION/Zsign-Package
 	branch = package
 [submodule "IDeviceKitten"]
 	path = IDeviceKitten
-	url = https://github.com/khcrysalis/IDeviceKit
+	url = https://github.com/CLARATION/IDeviceKit


### PR DESCRIPTION
## Summary
This PR updates the workflow and submodule configuration to keep our
GitHub Actions setup current and make release builds more reliable.

## Changes
- update `.gitmodules` to use the renamed `CLARATION` GitHub account for
  `Zsign` and `IDeviceKitten`
- upgrade `actions/checkout` from `v3` to `v6` in the `release` and
  `update_repo` workflows
- upgrade `EndBug/add-and-commit` from `v9` to `v10` in `update_repo`
- switch the release workflow to recursive submodule checkout
- disable persisted checkout credentials in the release workflow
- clear inherited GitHub extraheaders before running `git lfs pull` in
  `IDeviceKitten`

## Reason
The release workflow needs to fetch Git LFS assets from the
`IDeviceKitten` submodule reliably, and the submodule URLs should reflect
the renamed GitHub account.