### PR TITLE
Bump workflow action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
       
-      - name: Use Xcode 26.2
+      - name: Use Xcode 26.4
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
 
       - name: Compile Feather
         run: | 

--- a/.github/workflows/update_repo.yml
+++ b/.github/workflows/update_repo.yml
@@ -6,17 +6,17 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Update app-repo.json
         run: |
           ./update-repo.sh
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           default_author: github_actions
           message: "chore: update repo"


### PR DESCRIPTION
## Changes
- Switch Xcode to 26.4
- Update actions/checkout to v6 in both workflows and bump EndBug/add-and-commit to v10.

## Reason
Using Xcode 26.4 for compilation Feather resolved the app crash when adding or verifying a certificate.
Fixes https://github.com/CLARATION/Feather/issues/590

## Test
[Actions](https://github.com/marcinmajsc/Feather/actions/runs/24123030758)
[Release IPA](https://github.com/marcinmajsc/Feather/releases/tag/v2.7.0)
Run v2.7.0 on iOS 26.5