### PR TITLE
docs: fix typos in README, CONTRIBUTING, and a code comment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Feather is a sideloading app meant to be used on stock versions, to keep compatibility we have to utililize stock features to keep it working. As such, we have specific contribution rules in place to maintain this and Feathers integrity.
+Feather is a sideloading app meant to be used on stock versions, to keep compatibility we have to utilize stock features to keep it working. As such, we have specific contribution rules in place to maintain this and Feathers integrity.
 
 Any contributions should follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
 

--- a/Feather/Utilities/Handlers/TweakHandler.swift
+++ b/Feather/Utilities/Handlers/TweakHandler.swift
@@ -217,7 +217,7 @@ class TweakHandler {
 		}
 	}
 	
-	// Read extracted deb file, locate all neccessary contents to copy over to the .app
+	// Read extracted deb file, locate all necessary contents to copy over to the .app
 	private func _handleDirectories(at urls: [URL]) async throws {
 		enum DirectoryType: String {
 			case frameworks = "Frameworks"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Visit the [HOW IT WORKS](./HOW_IT_WORKS.md) page.
 - [idevice](https://github.com/jkcoxson/idevice) - Backend for builds with this included, used for communication with `installd`.
 - [*.backloop.dev](https://backloop.dev/) - localhost with public CA signed SSL certificate
 - [Vapor](https://github.com/vapor/vapor) - A server-side Swift HTTP web framework.
-- [Zsign](https://github.com/zhlynn/zsign) - Allowing to sign on-device, reimplimented to work on other platforms such as iOS.
+- [Zsign](https://github.com/zhlynn/zsign) - Allowing to sign on-device, reimplemented to work on other platforms such as iOS.
 - [LiveContainer](https://github.com/LiveContainer/LiveContainer) - Fixes/some help
 - [Nuke](https://github.com/kean/Nuke) - Image caching.
 - [Asspp](https://github.com/Lakr233/Asspp) - Some code for setting up the http server.


### PR DESCRIPTION
## Summary

Three small typo fixes. The CONTRIBUTING guide explicitly welcomes typo contributions.

- `README.md:64` — `reimplimented` → `reimplemented`
- `CONTRIBUTING.md:3` — `utililize` → `utilize`
- `Feather/Utilities/Handlers/TweakHandler.swift:220` — `neccessary` → `necessary` (code comment only)

## Test plan

- [x] Changes are docs/comment-only; no runtime behavior affected.
- [x] `git diff` reviewed — 3 lines changed, spelling only.