### PR TITLE
Feather(Views): add identifier search

### DIFF
--- a/Feather/Views/Sources/Apps/UIKit/SourceAppsTableRepresentableView.swift
+++ b/Feather/Views/Sources/Apps/UIKit/SourceAppsTableRepresentableView.swift
@@ -134,7 +134,7 @@ extension SourceAppsTableRepresentableView { class Coordinator: NSObject, UITabl
 	private func _calculateSortedApps() -> [(source: ASRepository, app: ASRepository.App)] {
 		let filtered = _allAppsWithSource.filter {
 			searchText.isEmpty ||
-				($0.app.id?.localizedCaseInsensitiveContains(searchText) ?? false) ||
+			($0.app.id?.range(of: searchText, options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US")) != nil) ||
 				($0.app.name?.localizedCaseInsensitiveContains(searchText) ?? false) ||
 				($0.app.description?.localizedCaseInsensitiveContains(searchText) ?? false) ||
 				($0.app.subtitle?.localizedCaseInsensitiveContains(searchText) ?? false) ||

--- a/Feather/Views/Sources/Apps/UIKit/SourceAppsTableRepresentableView.swift
+++ b/Feather/Views/Sources/Apps/UIKit/SourceAppsTableRepresentableView.swift
@@ -134,6 +134,7 @@ extension SourceAppsTableRepresentableView { class Coordinator: NSObject, UITabl
 	private func _calculateSortedApps() -> [(source: ASRepository, app: ASRepository.App)] {
 		let filtered = _allAppsWithSource.filter {
 			searchText.isEmpty ||
+				($0.app.id?.localizedCaseInsensitiveContains(searchText) ?? false) ||
 				($0.app.name?.localizedCaseInsensitiveContains(searchText) ?? false) ||
 				($0.app.description?.localizedCaseInsensitiveContains(searchText) ?? false) ||
 				($0.app.subtitle?.localizedCaseInsensitiveContains(searchText) ?? false) ||


### PR DESCRIPTION
This pull request makes a targeted improvement to the app search functionality. Now, when filtering apps, the search will also consider matches in the app's `id` field, in addition to name, description, and subtitle.

- Search functionality improvement:
  * Updated the `_calculateSortedApps` method in `SourceAppsTableRepresentableView.Coordinator` to include the app's `id` field in the search filter, allowing users to find apps by their bundle IDs.