### PR TITLE
Feature Proposal: Add 'Show in App Store' link to app detail page

### DIFF
--- a/Feather/Resources/Localizable.xcstrings
+++ b/Feather/Resources/Localizable.xcstrings
@@ -13851,6 +13851,17 @@
         }
       }
     },
+    "Show in App Store" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Store’da Görüntüle"
+          }
+        }
+      }
+    },
     "Show Sheet when Exporting" : {
       "comment" : "Archiving opens share sheet",
       "extractionState" : "manual",

--- a/Feather/Utilities/AppStoreHelper.swift
+++ b/Feather/Utilities/AppStoreHelper.swift
@@ -1,0 +1,43 @@
+//
+//  AppStoreHelper.swift
+//  Feather
+//
+//  Created by İsmail Carlık on 25.05.2026.
+//
+
+
+import SwiftUI
+
+struct AppStoreHelper {
+
+	private struct LookupResponse: Codable {
+		let results: [AppInfo]
+	}
+
+	private struct AppInfo: Codable {
+		let trackViewUrl: String
+	}
+
+	static func getURL(for bundleID: String) async -> URL? {
+
+		let urlString = "https://itunes.apple.com/lookup?bundleId=\(bundleID)"
+
+		guard let url = URL(string: urlString) else { return nil }
+
+		do {
+			let (data, _) = try await URLSession.shared.data(from: url)
+			let decoded = try JSONDecoder().decode(
+				LookupResponse.self,
+				from: data
+			)
+
+			if let linkString = decoded.results.first?.trackViewUrl {
+				return URL(string: linkString)
+			}
+		} catch {
+			print("AppStoreHelper Error: \(error.localizedDescription)")
+		}
+
+		return nil
+	}
+}

--- a/Feather/Utilities/AppStoreHelper.swift
+++ b/Feather/Utilities/AppStoreHelper.swift
@@ -5,8 +5,7 @@
 //  Created by İsmail Carlık on 25.05.2026.
 //
 
-
-import SwiftUI
+import Foundation
 
 struct AppStoreHelper {
 
@@ -20,12 +19,25 @@ struct AppStoreHelper {
 
 	static func getURL(for bundleID: String) async -> URL? {
 
-		let urlString = "https://itunes.apple.com/lookup?bundleId=\(bundleID)"
+		var components = URLComponents(
+			string: "https://itunes.apple.com/lookup"
+		)
+		
+		components?.queryItems = [
+			URLQueryItem(name: "bundleId", value: bundleID)
+		]
 
-		guard let url = URL(string: urlString) else { return nil }
+		guard let url = components?.url else { return nil }
 
 		do {
-			let (data, _) = try await URLSession.shared.data(from: url)
+			let (data, response) = try await URLSession.shared.data(from: url)
+			
+			guard let httpResponse = response as? HTTPURLResponse,
+				  httpResponse.statusCode == 200 else {
+				print("AppStoreHelper Error: Invalid response")
+				return nil
+			}
+			
 			let decoded = try JSONDecoder().decode(
 				LookupResponse.self,
 				from: data

--- a/Feather/Views/Sources/Apps/Detail/SourceAppsDetailView.swift
+++ b/Feather/Views/Sources/Apps/Detail/SourceAppsDetailView.swift
@@ -192,10 +192,14 @@ struct SourceAppsDetailView: View {
 		}
 		.flexibleHeaderScrollView()
 		.shouldSetInset()
-		.task {
-			if let bundleId = app.id {
-				_appStoreURL = await AppStoreHelper.getURL(for: bundleId)
+		.task(id: app.id) {
+			guard let bundleId = app.id else {
+				_appStoreURL = nil
+				return
 			}
+			
+			_appStoreURL = nil
+			_appStoreURL = await AppStoreHelper.getURL(for: bundleId)
 		}
 		.toolbar {
 			NBToolbarButton(

--- a/Feather/Views/Sources/Apps/Detail/SourceAppsDetailView.swift
+++ b/Feather/Views/Sources/Apps/Detail/SourceAppsDetailView.swift
@@ -18,6 +18,7 @@ struct SourceAppsDetailView: View {
 	@State var cancellable: AnyCancellable? // Combine
 	@State private var _isScreenshotPreviewPresented: Bool = false
 	@State private var _selectedScreenshotIndex: Int = 0
+	@State private var _appStoreURL: URL?
 	
 	var currentDownload: Download? {
 		downloadManager.getDownload(by: app.currentUniqueId)
@@ -139,6 +140,10 @@ struct SourceAppsDetailView: View {
 						if let bundleId = app.id {
 							_infoRow(title: .localized("Identifier"), value: bundleId)
 						}
+						
+						if let _appStoreURL {
+							Link("Show in App Store", destination: _appStoreURL)
+						}
 					}
 				}
 				
@@ -187,6 +192,11 @@ struct SourceAppsDetailView: View {
 		}
 		.flexibleHeaderScrollView()
 		.shouldSetInset()
+		.task {
+			if let bundleId = app.id {
+				_appStoreURL = await AppStoreHelper.getURL(for: bundleId)
+			}
+		}
 		.toolbar {
 			NBToolbarButton(
 				systemImage: "square.and.arrow.up",


### PR DESCRIPTION
This pull request adds the ability to display a link to the app's App Store page within the app detail view, if available. It introduces a helper for fetching the App Store URL based on the app's bundle identifier and updates the UI to show a localized link when the URL is present.

**App Store integration:**

* Added a new `AppStoreHelper` utility in `AppStoreHelper.swift` to asynchronously fetch the App Store URL for a given bundle ID using the iTunes Lookup API.
* Updated `SourceAppsDetailView` to fetch the App Store URL on view load and store it in the `_appStoreURL` state variable. [[1]](diffhunk://#diff-c2e046b32079f2e50173bd654185f6b7117a3c69d60b6963c7a585948b327936R21) [[2]](diffhunk://#diff-c2e046b32079f2e50173bd654185f6b7117a3c69d60b6963c7a585948b327936R195-R199)
* Modified the app detail UI to display a "Show in App Store" link when the App Store URL is available.

**Localization:**

* Added a Turkish translation for the "Show in App Store" string in `Localizable.xcstrings`.